### PR TITLE
fix landing page UI

### DIFF
--- a/app/(waitlist)/page.tsx
+++ b/app/(waitlist)/page.tsx
@@ -1,6 +1,5 @@
 import StructuredData from '@/components/structured-data'
 import { SiteHeader } from '@/components/site-header'
-import { SiteFooter } from '@/components/site-footer'
 import HeroSection from '@/app/_components/waitlist/hero-section';
 import TrustSection from '@/app/_components/waitlist/trust-section';
 import ImpactSection from '@/app/_components/waitlist/impact-section';
@@ -49,7 +48,14 @@ export default function Home() {
         </main>
 
         {/* Footer */}
-        <SiteFooter />
+        <footer className="bg-brand-blue">
+          <div className="mb-16 max-w-7xl mx-auto">
+            <p className="text-xs text-neutral-darkgray mb-4 md:mb-0 text-[#737373] mt-8">
+              &copy; {new Date().getFullYear()} Intuipay Holding PTE. LTD. All rights reserved.
+              <span className="text-neutral-darkgray ms-2">v{process.env.NEXT_PUBLIC_APP_VERSION}</span>
+            </p>
+          </div>
+        </footer>
       </div>
     </>
   )

--- a/app/_components/waitlist/cta-section.tsx
+++ b/app/_components/waitlist/cta-section.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export default function CtaSection() {
   return (
     <section className="bg-brand-blue rounded-tl-[64px] rounded-tr-[64px]">
-      <div className="max-w-screen mx-auto px-8 py-16 md:px-12 md:py-28 lg:px-16 lg:py-28 xl:p-28 flex flex-col justify-start items-center gap-12 md:gap-16">
+      <div className="max-w-7xl mx-auto px-8 py-16 md:px-12 md:py-28 lg:px-16 lg:py-28 xl:p-28 flex flex-col justify-start items-center gap-12 md:gap-16">
         <div className="flex flex-col justify-start items-center gap-6">
           <div className="text-black text-6xl font-medium font-neue-montreal capitalize text-center">Simplify Education Giving</div>
           <div className="text-black/50 text-xl font-normal">

--- a/app/_components/waitlist/cta-section.tsx
+++ b/app/_components/waitlist/cta-section.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export default function CtaSection() {
   return (
     <section className="bg-brand-blue rounded-tl-[64px] rounded-tr-[64px]">
-      <div className="max-w-7xl mx-auto px-8 py-16 md:px-12 md:py-28 lg:px-16 lg:py-28 xl:p-28 flex flex-col justify-start items-center gap-12 md:gap-16">
+      <div className="max-w-screen mx-auto px-8 py-16 md:px-12 md:py-28 lg:px-16 lg:py-28 xl:p-28 flex flex-col justify-start items-center gap-12 md:gap-16">
         <div className="flex flex-col justify-start items-center gap-6">
           <div className="text-black text-6xl font-medium font-neue-montreal capitalize text-center">Simplify Education Giving</div>
           <div className="text-black/50 text-xl font-normal">

--- a/app/_components/waitlist/dashboard-section.tsx
+++ b/app/_components/waitlist/dashboard-section.tsx
@@ -3,7 +3,7 @@ import { AnimatedCounter } from '@/components/animated-counter';
 
 export default function DashboardSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">

--- a/app/_components/waitlist/dashboard-section.tsx
+++ b/app/_components/waitlist/dashboard-section.tsx
@@ -93,7 +93,7 @@ export default function DashboardSection() {
               <span className="text-black/70 text-base md:text-xl font-semibold leading-tight md:leading-normal">
                 Create account
               </span>
-              <ArrowUpRightIcon size={24} />
+              <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
           </div>
         </div>
@@ -104,21 +104,21 @@ export default function DashboardSection() {
         {/* Features Row */}
         <div className="flex flex-col md:flex-row gap-8 md:gap-24">
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <MoneyIcon size={32} />
+            <MoneyIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Monitor real-time donations and currency breakdowns
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <ReceiptIcon size={32} />
+            <ReceiptIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Manage receipts, project listings, and donor data
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <FilesIcon size={32} />
+            <FilesIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Download reports for finance and tax teams
             </div>

--- a/app/_components/waitlist/dashboard-section.tsx
+++ b/app/_components/waitlist/dashboard-section.tsx
@@ -1,14 +1,29 @@
+'use client';
+
 import { MoneyIcon, ReceiptIcon, FilesIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
 import { AnimatedCounter } from '@/components/animated-counter';
+import { motion } from 'framer-motion';
+import { sectionMotionVariants, sectionMotionProps } from './motion';
 
 export default function DashboardSection() {
+  const { itemVariants } = sectionMotionVariants;
+
   return (
     <section className="py-16 max-w-7xl mx-auto">
-      <div className="flex flex-col gap-8 md:gap-16">
+      <motion.div
+        className="flex flex-col gap-8 md:gap-16"
+        {...sectionMotionProps}
+      >
         {/* Main Content Row */}
-        <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">
+        <motion.div
+          className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center"
+          variants={itemVariants}
+        >
           {/* Dashboard Demo - First on mobile, Right on desktop */}
-          <div className="order-1 lg:order-2 flex-1 bg-purple-100 rounded-[32px] flex items-center justify-center pl-4 lg:pl-8 pr-0 py-0">
+          <motion.div
+            className="order-1 lg:order-2 flex-1 bg-purple-100 rounded-[32px] flex items-center justify-center pl-4 lg:pl-8 pr-0 py-0"
+            variants={itemVariants}
+          >
             <div className="w-full flex flex-col gap-4 py-12 lg:py-32 lg:gap-8">
               {/* Main Balance Card */}
               <div className="bg-white rounded-l-2xl shadow-[0px_4px_12px_0px_rgba(0,0,0,0.08)] px-4 lg:px-8 py-3 lg:py-6">
@@ -73,10 +88,13 @@ export default function DashboardSection() {
                 </div>
               </div>
             </div>
-          </div>
+          </motion.div>
 
           {/* Text Content - Second on mobile, Left on desktop */}
-          <div className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch">
+          <motion.div
+            className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 lg:gap-6 mb-6 lg:mb-8">
               <div className="text-blue-600 text-base font-medium font-neue-montreal capitalize tracking-wide">
                 Control, Track, Report
@@ -95,36 +113,51 @@ export default function DashboardSection() {
               </span>
               <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
 
         {/* Divider Line */}
-        <div className="w-full h-px bg-gray-200"></div>
+        <motion.div
+          className="w-full h-px bg-gray-200"
+          variants={itemVariants}
+        ></motion.div>
 
         {/* Features Row */}
-        <div className="flex flex-col md:flex-row gap-8 md:gap-24">
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+        <motion.div
+          className="flex flex-col md:flex-row gap-8 md:gap-24"
+          variants={itemVariants}
+        >
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <MoneyIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Monitor real-time donations and currency breakdowns
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <ReceiptIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Manage receipts, project listings, and donor data
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <FilesIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Download reports for finance and tax teams
             </div>
-          </div>
-        </div>
-      </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/app/_components/waitlist/dashboard-section.tsx
+++ b/app/_components/waitlist/dashboard-section.tsx
@@ -3,7 +3,7 @@ import { AnimatedCounter } from '@/components/animated-counter';
 
 export default function DashboardSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-7xl mx-auto">
+    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">

--- a/app/_components/waitlist/dashboard-section.tsx
+++ b/app/_components/waitlist/dashboard-section.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link'
 import { MoneyIcon, ReceiptIcon, FilesIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
 import { AnimatedCounter } from '@/components/animated-counter';
 import { motion } from 'framer-motion';
@@ -36,7 +37,6 @@ export default function DashboardSection() {
                       end={12345}
                       prefix="$"
                       suffix=".00"
-                      duration={2500}
                     />
                   </div>
                   <div className="text-black/60 text-xs lg:text-sm font-semibold leading-5">
@@ -55,7 +55,6 @@ export default function DashboardSection() {
                         end={1234}
                         prefix="$"
                         suffix=".00"
-                        duration={2000}
                       />
                     </div>
                     <div className="flex items-center gap-1">
@@ -75,7 +74,6 @@ export default function DashboardSection() {
                         end={1234}
                         prefix="$"
                         suffix=".00"
-                        duration={2200}
                       />
                     </div>
                     <div className="flex items-center gap-1">
@@ -107,12 +105,12 @@ export default function DashboardSection() {
               </div>
             </div>
 
-            <button className="flex items-center gap-2 px-6 lg:px-8 py-3 lg:py-4 border border-black/70 rounded-full w-fit">
+            <Link href="https://dash.intuipay.xyz" className="flex items-center gap-2 px-6 lg:px-8 py-3 lg:py-4 border border-black/70 rounded-full w-fit">
               <span className="text-black/70 text-base md:text-xl font-semibold leading-tight md:leading-normal">
                 Create account
               </span>
               <ArrowUpRightIcon size={24} className="text-black/70" />
-            </button>
+            </Link>
           </motion.div>
         </motion.div>
 

--- a/app/_components/waitlist/footer-links-section.tsx
+++ b/app/_components/waitlist/footer-links-section.tsx
@@ -1,7 +1,7 @@
 export default function FooterLinksSection() {
   return (
     <section className="bg-brand-blue">
-      <div className="py-16 max-w-7xl mx-auto">
+      <div className="max-w-7xl mx-auto">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8">
           {/* Left Column on Mobile - Product */}
           <div className="flex flex-col gap-4 sm:gap-6">

--- a/app/_components/waitlist/footer-links-section.tsx
+++ b/app/_components/waitlist/footer-links-section.tsx
@@ -1,7 +1,7 @@
 export default function FooterLinksSection() {
   return (
     <section className="bg-brand-blue">
-      <div className="max-w-7xl mx-auto px-6 md:px-12 lg:px-16 xl:px-28 py-12">
+      <div className="max-w-screen mx-auto px-6 md:px-12 lg:px-16 xl:px-28 py-12">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8">
           {/* Left Column on Mobile - Product */}
           <div className="flex flex-col gap-4 sm:gap-6">

--- a/app/_components/waitlist/footer-links-section.tsx
+++ b/app/_components/waitlist/footer-links-section.tsx
@@ -1,7 +1,7 @@
 export default function FooterLinksSection() {
   return (
     <section className="bg-brand-blue">
-      <div className="max-w-screen mx-auto px-6 md:px-12 lg:px-16 xl:px-28 py-12">
+      <div className="py-16 max-w-7xl mx-auto">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-6 sm:gap-8">
           {/* Left Column on Mobile - Product */}
           <div className="flex flex-col gap-4 sm:gap-6">

--- a/app/_components/waitlist/hero-section.tsx
+++ b/app/_components/waitlist/hero-section.tsx
@@ -4,7 +4,7 @@ export default function HeroSection() {
   return (
     <section className="xl:py-16 xl:px-16 2xl:px-20">
       <div className="bg-brand-blue xl:rounded-3xl p-6 md:p-10 xl:p-16 2xl:p-20">
-        <div className="max-w-screen mx-auto flex flex-col xl:flex-row xl:items-center xl:gap-16 gap-12">
+        <div className="max-w-7xl mx-auto flex flex-col xl:flex-row xl:items-center xl:gap-16 gap-12">
           <div className="xl:w-1/2 flex-none">
             <h1 className="text-3xl sm:text-5xl xl:text-4xl 2xl:text-5xl font-medium mb-6 leading-tight">
               Where{' '}

--- a/app/_components/waitlist/hero-section.tsx
+++ b/app/_components/waitlist/hero-section.tsx
@@ -6,7 +6,7 @@ export default function HeroSection() {
       <div className="bg-brand-blue xl:rounded-3xl p-6 md:p-10 xl:p-16 2xl:p-20">
         <div className="max-w-7xl mx-auto flex flex-col xl:flex-row xl:items-center xl:gap-16 gap-12">
           <div className="xl:w-1/2 flex-none">
-            <h1 className="text-3xl sm:text-5xl xl:text-4xl 2xl:text-5xl font-medium mb-6 leading-tight">
+            <h1 className="text-3xl sm:text-5xl xl:text-4xl 2xl:text-5xl font-medium font-neue-montreal mb-6 leading-tight">
               Where{' '}
               <span className="inline-flex items-center align-top w-20 relative me-2" aria-label="Flags">
                 <span className="size-6 md:size-8 text-sm md:text-lg border rounded-full flex justify-center items-center absolute z-40 top-0 left-0 bg-white">🇸🇬</span>

--- a/app/_components/waitlist/hero-section.tsx
+++ b/app/_components/waitlist/hero-section.tsx
@@ -4,7 +4,7 @@ export default function HeroSection() {
   return (
     <section className="xl:py-16 xl:px-16 2xl:px-20">
       <div className="bg-brand-blue xl:rounded-3xl p-6 md:p-10 xl:p-16 2xl:p-20">
-        <div className="max-w-7xl mx-auto flex flex-col xl:flex-row xl:items-center xl:gap-16 gap-12">
+        <div className="max-w-screen mx-auto flex flex-col xl:flex-row xl:items-center xl:gap-16 gap-12">
           <div className="xl:w-1/2 flex-none">
             <h1 className="text-3xl sm:text-5xl xl:text-4xl 2xl:text-5xl font-medium mb-6 leading-tight">
               Where{' '}

--- a/app/_components/waitlist/impact-section.tsx
+++ b/app/_components/waitlist/impact-section.tsx
@@ -1,18 +1,37 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { sectionMotionVariants, sectionMotionProps } from './motion';
+
 export default function ImpactSection() {
+  const { itemVariants } = sectionMotionVariants;
+
   return (
     <section className="py-16 max-w-7xl mx-auto">
-      <div className="flex flex-col items-center gap-12 md:gap-24">
-        <div className="flex flex-col items-center gap-6 md:gap-8 w-full">
+      <motion.div
+        className="flex flex-col items-center gap-12 md:gap-24"
+        {...sectionMotionProps}
+      >
+        <motion.div
+          className="flex flex-col items-center gap-6 md:gap-8 w-full"
+          variants={itemVariants}
+        >
           <div className="text-black text-6xl font-medium font-neue-montreal capitalize text-center">
             Creating Exceptional Impact
           </div>
           <div className="text-black/50 text-sm md:text-base font-normal text-center leading-normal">
             Our mission is to help you reach your mission. Crypto, Stock, and Legacy Giving - now in one enterprise-ready donation platform. Sign up today and raise more money to impact more lives.
           </div>
-        </div>
+        </motion.div>
 
-        <div className="flex flex-col md:flex-row gap-8 w-full">
-          <div className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12">
+        <motion.div
+          className="flex flex-col md:flex-row gap-8 w-full"
+          variants={itemVariants}
+        >
+          <motion.div
+            className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 md:gap-8">
               <div className="text-black text-6xl font-medium font-neue-montreal capitalize">
                 70%
@@ -21,9 +40,12 @@ export default function ImpactSection() {
                 of Forbes' top 100 charities accept crypto donations
               </div>
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12">
+          <motion.div
+            className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 md:gap-8">
               <div className="text-black text-6xl font-medium font-neue-montreal capitalize">
                 600Mn
@@ -32,9 +54,12 @@ export default function ImpactSection() {
                 crypto users worldwide
               </div>
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12">
+          <motion.div
+            className="flex-1 bg-neutral-100 rounded-[32px] p-6 md:p-12"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 md:gap-8">
               <div className="text-black text-6xl font-medium font-neue-montreal capitalize">
                 $2.5B
@@ -43,9 +68,9 @@ export default function ImpactSection() {
                 crypto giving expected in 2025 with growing trends
               </div>
             </div>
-          </div>
-        </div>
-      </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/app/_components/waitlist/impact-section.tsx
+++ b/app/_components/waitlist/impact-section.tsx
@@ -1,6 +1,6 @@
 export default function ImpactSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col items-center gap-12 md:gap-24">
         <div className="flex flex-col items-center gap-6 md:gap-8 w-full">
           <div className="text-black text-6xl font-medium font-neue-montreal capitalize text-center">

--- a/app/_components/waitlist/impact-section.tsx
+++ b/app/_components/waitlist/impact-section.tsx
@@ -1,6 +1,6 @@
 export default function ImpactSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-7xl mx-auto">
+    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
       <div className="flex flex-col items-center gap-12 md:gap-24">
         <div className="flex flex-col items-center gap-6 md:gap-8 w-full">
           <div className="text-black text-6xl font-medium font-neue-montreal capitalize text-center">

--- a/app/_components/waitlist/motion.ts
+++ b/app/_components/waitlist/motion.ts
@@ -1,0 +1,36 @@
+// Common motion variants for waitlist sections
+export const sectionMotionVariants = {
+  containerVariants: {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.2,
+        delayChildren: 0.3
+      }
+    }
+  },
+  
+  itemVariants: {
+    hidden: { 
+      opacity: 0, 
+      y: 50 
+    },
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: 0.8,
+        ease: "easeOut"
+      }
+    }
+  }
+};
+
+// Common motion props for section containers
+export const sectionMotionProps = {
+  variants: sectionMotionVariants.containerVariants,
+  initial: "hidden",
+  whileInView: "visible",
+  viewport: { once: true, amount: 0.2 }
+};

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -18,12 +18,12 @@ export default function ShowcaseSection() {
               <div className="bg-white rounded-3xl shadow-[0px_4px_12px_0px_rgba(0,0,0,0.08)] p-4 lg:p-8">
                 <div className="flex flex-col gap-3 lg:gap-6">
                   {/* Project Info */}
-                  <div className="flex flex-col gap-2 lg:gap-3">
-                    <div className="text-black text-sm lg:text-base font-semibold leading-6">
-                      NeuroBridge
+                  <div className="self-stretch flex flex-col justify-start items-start gap-3">
+                    <div className="bg-neutral-100 inline-flex justify-center items-center gap-2.5">
+                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">NeuroBridge </div>
                     </div>
-                    <div className="text-black text-sm lg:text-base font-semibold leading-6">
-                      Bridging Brain Health and AI for Early Alzheimer's Detection
+                    <div className="self-stretch bg-neutral-100 inline-flex justify-center items-center gap-2.5">
+                      <div className="flex-1 justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Bridging Brain Health and AI for Early Alzheimer’s Detection</div>
                     </div>
                   </div>
 
@@ -42,12 +42,12 @@ export default function ShowcaseSection() {
                   </div>
 
                   {/* Total Raised */}
-                  <div className="flex justify-between items-center">
-                    <div className="text-black text-sm lg:text-base font-semibold leading-6">
-                      Total Raised
+                  <div className="self-stretch inline-flex justify-between items-center">
+                    <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
+                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Total Rasied</div>
                     </div>
-                    <div className="text-black text-sm lg:text-base font-semibold leading-6">
-                      $ 123,456.00
+                    <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
+                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">$ 123,4567.00</div>
                     </div>
                   </div>
                 </div>

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -35,12 +35,8 @@ export default function ShowcaseSection() {
                 <div className="flex flex-col gap-3 lg:gap-6">
                   {/* Project Info */}
                   <div className="self-stretch flex flex-col justify-start items-start gap-3">
-                    <div className="bg-neutral-100 inline-flex justify-center items-center gap-2.5">
-                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">NeuroBridge </div>
-                    </div>
-                    <div className="self-stretch bg-neutral-100 inline-flex justify-center items-center gap-2.5">
-                      <div className="flex-1 justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Bridging Brain Health and AI for Early Alzheimer’s Detection</div>
-                    </div>
+                    <div className="bg-neutral-100 h-6 w-32 rounded"></div>
+                    <div className="bg-neutral-100 h-6 w-full rounded"></div>
                   </div>
 
                   {/* Verification */}
@@ -59,12 +55,8 @@ export default function ShowcaseSection() {
 
                   {/* Total Raised */}
                   <div className="self-stretch inline-flex justify-between items-center">
-                    <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
-                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Total Raised</div>
-                    </div>
-                    <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
-                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">$ 123,4567.00</div>
-                    </div>
+                    <div className="bg-neutral-100 h-6 w-24 rounded"></div>
+                    <div className="bg-neutral-100 h-6 w-32 rounded"></div>
                   </div>
                 </div>
               </div>

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -78,7 +78,7 @@ export default function ShowcaseSection() {
               <span className="text-black/70 text-base md:text-xl font-semibold leading-tight md:leading-normal">
                 Explore Marketplace
               </span>
-              <ArrowUpRightIcon size={24} />
+              <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
           </div>
         </div>
@@ -89,21 +89,21 @@ export default function ShowcaseSection() {
         {/* Features Row */}
         <div className="flex flex-col md:flex-row gap-8 md:gap-24">
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <GraduationCapIcon size={32} />
+            <GraduationCapIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Verified projects from universities and researchers in 20+ countries
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <ArrowsDownUpIcon size={32} />
+            <ArrowsDownUpIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Transparent donation tracking
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <MagnifyingGlassIcon size={32} />
+            <MagnifyingGlassIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Direct support to institutions or specific researchers
             </div>

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -2,7 +2,7 @@ import { GraduationCapIcon, ArrowsDownUpIcon, MagnifyingGlassIcon, ArrowUpRightI
 
 export default function ShowcaseSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link'
 import { GraduationCapIcon, ArrowsDownUpIcon, MagnifyingGlassIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
 import { motion } from 'framer-motion';
 import { sectionMotionVariants, sectionMotionProps } from './motion';
@@ -92,12 +93,12 @@ export default function ShowcaseSection() {
               </div>
             </div>
 
-            <button className="flex items-center gap-2 px-6 lg:px-8 py-3 lg:py-4 border border-black/70 rounded-full w-fit">
+            <Link href="/projects" className="flex items-center gap-2 px-6 lg:px-8 py-3 lg:py-4 border border-black/70 rounded-full w-fit">
               <span className="text-black/70 text-base md:text-xl font-semibold leading-tight md:leading-normal">
                 Explore Marketplace
               </span>
               <ArrowUpRightIcon size={24} className="text-black/70" />
-            </button>
+            </Link>
           </motion.div>
         </motion.div>
 

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -60,7 +60,7 @@ export default function ShowcaseSection() {
                   {/* Total Raised */}
                   <div className="self-stretch inline-flex justify-between items-center">
                     <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
-                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Total Rasied</div>
+                      <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">Total Raised</div>
                     </div>
                     <div className="bg-neutral-100 flex justify-center items-center gap-2.5">
                       <div className="justify-start text-neutral-100 text-base font-semibold font-['Inter'] leading-normal">$ 123,4567.00</div>

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -1,13 +1,28 @@
+'use client';
+
 import { GraduationCapIcon, ArrowsDownUpIcon, MagnifyingGlassIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
+import { motion } from 'framer-motion';
+import { sectionMotionVariants, sectionMotionProps } from './motion';
 
 export default function ShowcaseSection() {
+  const { itemVariants } = sectionMotionVariants;
+
   return (
     <section className="py-16 max-w-7xl mx-auto">
-      <div className="flex flex-col gap-8 md:gap-16">
+      <motion.div
+        className="flex flex-col gap-8 md:gap-16"
+        {...sectionMotionProps}
+      >
         {/* Main Content Row */}
-        <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">
+        <motion.div
+          className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center"
+          variants={itemVariants}
+        >
           {/* Project Demo - First on mobile, Right on desktop */}
-          <div className="order-1 lg:order-2 flex-1 bg-yellow-50 rounded-[32px] flex items-center justify-center p-4 lg:p-8 relative overflow-hidden">
+          <motion.div
+            className="order-1 lg:order-2 flex-1 bg-yellow-50 rounded-[32px] flex items-center justify-center p-4 lg:p-8 relative overflow-hidden"
+            variants={itemVariants}
+          >
             <div className="w-full flex flex-col justify-center items-center gap-4 lg:gap-8">
               {/* Top Card - Partially hidden */}
               <div className="self-stretch bg-amber-100 rounded-3xl flex flex-col justify-start items-start -mt-16 md:-mt-20 lg:-mt-24">
@@ -58,10 +73,13 @@ export default function ShowcaseSection() {
                 <div className="self-stretch h-20 md:h-24 lg:h-32 p-8" />
               </div>
             </div>
-          </div>
+          </motion.div>
 
           {/* Text Content - Second on mobile, Left on desktop */}
-          <div className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch">
+          <motion.div
+            className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 lg:gap-6 mb-6 lg:mb-8">
               <div className="text-blue-600 text-base font-medium font-neue-montreal capitalize tracking-wide">
                 Reach A Global Community
@@ -80,36 +98,51 @@ export default function ShowcaseSection() {
               </span>
               <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
 
         {/* Divider Line */}
-        <div className="w-full h-px bg-gray-200"></div>
+        <motion.div
+          className="w-full h-px bg-gray-200"
+          variants={itemVariants}
+        ></motion.div>
 
         {/* Features Row */}
-        <div className="flex flex-col md:flex-row gap-8 md:gap-24">
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+        <motion.div
+          className="flex flex-col md:flex-row gap-8 md:gap-24"
+          variants={itemVariants}
+        >
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <GraduationCapIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Verified projects from universities and researchers in 20+ countries
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <ArrowsDownUpIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Transparent donation tracking
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <MagnifyingGlassIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Direct support to institutions or specific researchers
             </div>
-          </div>
-        </div>
-      </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/app/_components/waitlist/showcase-section.tsx
+++ b/app/_components/waitlist/showcase-section.tsx
@@ -2,7 +2,7 @@ import { GraduationCapIcon, ArrowsDownUpIcon, MagnifyingGlassIcon, ArrowUpRightI
 
 export default function ShowcaseSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-7xl mx-auto">
+    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-center">

--- a/app/_components/waitlist/testimonial-section.tsx
+++ b/app/_components/waitlist/testimonial-section.tsx
@@ -1,32 +1,54 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { sectionMotionVariants, sectionMotionProps } from './motion';
+
 export default function TestimonialSection() {
+  const { itemVariants } = sectionMotionVariants;
+
   return (
     <section className="py-16 max-w-7xl mx-auto">
-      <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-start">
-        <div className="flex-1 text-black text-6xl font-medium font-neue-montreal capitalize leading-normal">
+      <motion.div
+        className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-start"
+        {...sectionMotionProps}
+      >
+        <motion.div
+          className="flex-1 text-black text-6xl font-medium font-neue-montreal capitalize leading-normal"
+          variants={itemVariants}
+        >
           Testimonial
-        </div>
-        <div className="flex-1 flex flex-col gap-12 lg:gap-24 items-start justify-center">
+        </motion.div>
+        <motion.div
+          className="flex-1 flex flex-col gap-12 lg:gap-24 items-start justify-center"
+          variants={itemVariants}
+        >
           {/* First Testimonial */}
-          <div className="flex flex-col gap-4 lg:gap-8 w-full">
+          <motion.div
+            className="flex flex-col gap-4 lg:gap-8 w-full"
+            variants={itemVariants}
+          >
             <div className="text-black/70 text-sm lg:text-base font-normal leading-normal w-full">
               "Intuipay has been great. The website is easy to navigate and almost everything is automated. Whenever we have a question, the team is always quick to get back to us. We can incorporate Intuipay's features into our website and customize it to our brand standards."
             </div>
             <div className="text-black/70 text-lg lg:text-xl font-semibold leading-normal w-full">
               Name / logo
             </div>
-          </div>
+          </motion.div>
 
           {/* Second Testimonial */}
-          <div className="flex flex-col gap-4 lg:gap-8 w-full">
+          <motion.div
+            className="flex flex-col gap-4 lg:gap-8 w-full"
+            variants={itemVariants}
+          >
             <div className="text-black/70 text-sm lg:text-base font-normal leading-normal w-full">
               "Intuipay has been great. The website is easy to navigate and almost everything is automated. Whenever we have a question, the team is always quick to get back to us. We can incorporate Engiven's features into our website and customize it to our brand standards."
             </div>
             <div className="text-black/70 text-lg lg:text-xl font-semibold leading-normal w-full">
               Name / logo
             </div>
-          </div>
-        </div>
-      </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/app/_components/waitlist/testimonial-section.tsx
+++ b/app/_components/waitlist/testimonial-section.tsx
@@ -1,6 +1,6 @@
 export default function TestimonialSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-7xl mx-auto">
+    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
       <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-start">
         <div className="flex-1 text-black text-6xl font-medium font-neue-montreal capitalize leading-normal">
           Testimonial

--- a/app/_components/waitlist/testimonial-section.tsx
+++ b/app/_components/waitlist/testimonial-section.tsx
@@ -1,6 +1,6 @@
 export default function TestimonialSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col lg:flex-row gap-8 lg:gap-24 items-start">
         <div className="flex-1 text-black text-6xl font-medium font-neue-montreal capitalize leading-normal">
           Testimonial

--- a/app/_components/waitlist/trust-section.tsx
+++ b/app/_components/waitlist/trust-section.tsx
@@ -23,7 +23,7 @@ export default function TrustSection() {
   ]
 
   return (
-    <section className="py-12 max-w-screen mx-auto px-16">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col justify-center items-center gap-12">
         <div className="text-center">
           <span className="text-black text-3xl font-medium">Trust by </span>

--- a/app/_components/waitlist/trust-section.tsx
+++ b/app/_components/waitlist/trust-section.tsx
@@ -23,7 +23,7 @@ export default function TrustSection() {
   ]
 
   return (
-    <section className="py-12 max-w-7xl mx-auto px-16">
+    <section className="py-12 max-w-screen mx-auto px-16">
       <div className="flex flex-col justify-center items-center gap-12">
         <div className="text-center">
           <span className="text-black text-3xl font-medium">Trust by </span>

--- a/app/_components/waitlist/widget-section.tsx
+++ b/app/_components/waitlist/widget-section.tsx
@@ -40,7 +40,7 @@ export default function WidgetSection() {
               <span className="text-black/70 text-base md:text-xl font-semibold leading-tight md:leading-normal">
                 See how it works
               </span>
-              <ArrowUpRightIcon size={24} />
+              <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
           </div>
         </div>
@@ -51,21 +51,21 @@ export default function WidgetSection() {
         {/* Features Row */}
         <div className="flex flex-col md:flex-row gap-8 md:gap-24">
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <CodeIcon size={32} />
+            <CodeIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Simple HTML iframe embedding set-up
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <CoinsIcon size={32} />
+            <CoinsIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               30+ cryptocurrencies accepted
             </div>
           </div>
 
           <div className="flex-1 flex flex-col gap-4 md:gap-6">
-            <GlobeIcon size={32} />
+            <GlobeIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Automatic conversion to local fiat currencies
             </div>

--- a/app/_components/waitlist/widget-section.tsx
+++ b/app/_components/waitlist/widget-section.tsx
@@ -2,7 +2,7 @@ import { CodeIcon, CoinsIcon, GlobeIcon, ArrowUpRightIcon } from '@phosphor-icon
 
 export default function WidgetSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-7xl mx-auto">
+    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-16 items-center">

--- a/app/_components/waitlist/widget-section.tsx
+++ b/app/_components/waitlist/widget-section.tsx
@@ -1,13 +1,28 @@
+'use client';
+
 import { CodeIcon, CoinsIcon, GlobeIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
+import { motion } from 'framer-motion';
+import { sectionMotionVariants, sectionMotionProps } from './motion';
 
 export default function WidgetSection() {
+  const { itemVariants } = sectionMotionVariants;
+
   return (
     <section className="py-16 max-w-7xl mx-auto">
-      <div className="flex flex-col gap-8 md:gap-16">
+      <motion.div
+        className="flex flex-col gap-8 md:gap-16"
+        {...sectionMotionProps}
+      >
         {/* Main Content Row */}
-        <div className="flex flex-col lg:flex-row gap-8 lg:gap-16 items-center">
+        <motion.div
+          className="flex flex-col lg:flex-row gap-8 lg:gap-16 items-center"
+          variants={itemVariants}
+        >
           {/* Widget Demo - First on mobile, Right on desktop */}
-          <div className="order-1 lg:order-2 flex-1 bg-lime-50 rounded-[32px] flex items-center justify-center py-32 px-4 lg:px-8">
+          <motion.div
+            className="order-1 lg:order-2 flex-1 bg-lime-50 rounded-[32px] flex items-center justify-center py-32 px-4 lg:px-8"
+            variants={itemVariants}
+          >
             <div className="w-full h-80 shadow-[0px_4px_12px_0px_rgba(0,0,0,0.08)] rounded-2xl overflow-hidden">
               <video
                 src="/images/mockup_light.mp4"
@@ -20,10 +35,13 @@ export default function WidgetSection() {
                 Your browser does not support the video tag.
               </video>
             </div>
-          </div>
+          </motion.div>
 
           {/* Text Content - Second on mobile, Left on desktop */}
-          <div className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch">
+          <motion.div
+            className="order-2 lg:order-1 flex-1 flex flex-col justify-between items-start self-stretch"
+            variants={itemVariants}
+          >
             <div className="flex flex-col gap-4 lg:gap-6">
               <div className="text-blue-600 text-base font-medium font-neue-montreal capitalize tracking-wide">
                 Accept Crypto with Ease
@@ -42,36 +60,51 @@ export default function WidgetSection() {
               </span>
               <ArrowUpRightIcon size={24} className="text-black/70" />
             </button>
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
 
         {/* Divider Line */}
-        <div className="w-full h-px bg-gray-200"></div>
+        <motion.div
+          className="w-full h-px bg-gray-200"
+          variants={itemVariants}
+        ></motion.div>
 
         {/* Features Row */}
-        <div className="flex flex-col md:flex-row gap-8 md:gap-24">
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+        <motion.div
+          className="flex flex-col md:flex-row gap-8 md:gap-24"
+          variants={itemVariants}
+        >
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <CodeIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Simple HTML iframe embedding set-up
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <CoinsIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               30+ cryptocurrencies accepted
             </div>
-          </div>
+          </motion.div>
 
-          <div className="flex-1 flex flex-col gap-4 md:gap-6">
+          <motion.div
+            className="flex-1 flex flex-col gap-4 md:gap-6"
+            variants={itemVariants}
+          >
             <GlobeIcon size={32} className="text-black/70" />
             <div className="text-black/70 text-sm md:text-base font-normal leading-6">
               Automatic conversion to local fiat currencies
             </div>
-          </div>
-        </div>
-      </div>
+          </motion.div>
+        </motion.div>
+      </motion.div>
     </section>
   );
 }

--- a/app/_components/waitlist/widget-section.tsx
+++ b/app/_components/waitlist/widget-section.tsx
@@ -2,7 +2,7 @@ import { CodeIcon, CoinsIcon, GlobeIcon, ArrowUpRightIcon } from '@phosphor-icon
 
 export default function WidgetSection() {
   return (
-    <section className="px-8 py-12 md:px-12 md:py-20 lg:px-16 lg:py-28 xl:p-28 max-w-screen mx-auto">
+    <section className="py-16 max-w-7xl mx-auto">
       <div className="flex flex-col gap-8 md:gap-16">
         {/* Main Content Row */}
         <div className="flex flex-col lg:flex-row gap-8 lg:gap-16 items-center">

--- a/components/animated-counter.tsx
+++ b/components/animated-counter.tsx
@@ -1,57 +1,96 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef, useCallback } from 'react'
 import { motion, useInView } from 'framer-motion'
-import { useRef } from 'react'
 
 interface AnimatedCounterProps {
   end: number
-  duration?: number
   suffix?: string
   prefix?: string
   className?: string
+  rollInterval?: number // 滚动间隔时间（毫秒）
+  rollRange?: number // 随机滚动的范围比例（相对于end值）
 }
 
-export function AnimatedCounter({ 
-  end, 
-  duration = 2000, 
-  suffix = '', 
+export function AnimatedCounter({
+  end,
+  suffix = '',
   prefix = '',
-  className = ''
+  className = '',
+  rollInterval = 150, // 默认150ms滚动一次
+  rollRange = 0.4 // 默认在目标值的±40%范围内随机滚动
 }: AnimatedCounterProps) {
   const [count, setCount] = useState(0)
-  const ref = useRef(null)
+  const [isHovered, setIsHovered] = useState(false)
+  const ref = useRef<HTMLSpanElement>(null)
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const isInView = useInView(ref, { once: true, margin: '-100px' })
+
+  // 生成随机数值的函数
+  const generateRandomCount = useCallback(() => {
+    const range = Math.floor(end * rollRange)
+    const min = Math.max(0, end - range)
+    const max = end + range
+    return Math.floor(Math.random() * (max - min + 1)) + min
+  }, [end, rollRange])
+
+  // 启动随机滚动
+  const startRolling = useCallback(() => {
+    if (intervalRef.current) return
+
+    intervalRef.current = setInterval(() => {
+      setCount(generateRandomCount())
+    }, rollInterval)
+  }, [generateRandomCount, rollInterval])
+
+  // 停止随机滚动
+  const stopRolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }, [])
+
+  // 鼠标进入时暂停滚动并显示目标值
+  const handleMouseEnter = useCallback(() => {
+    setIsHovered(true)
+    stopRolling()
+    setCount(end)
+  }, [end, stopRolling])
+
+  // 鼠标离开时继续滚动
+  const handleMouseLeave = useCallback(() => {
+    setIsHovered(false)
+    if (isInView) {
+      startRolling()
+    }
+  }, [isInView, startRolling])
 
   useEffect(() => {
     if (!isInView) return
 
-    let startTime: number
-    let animationFrame: number
+    // 初始显示目标值
+    setCount(end)
 
-    const animate = (currentTime: number) => {
-      if (!startTime) startTime = currentTime
-      const progress = Math.min((currentTime - startTime) / duration, 1)
-      
-      // 使用缓动函数让动画更自然
-      const easeOutCubic = 1 - Math.pow(1 - progress, 3)
-      const currentCount = Math.floor(easeOutCubic * end)
-      
-      setCount(currentCount)
-
-      if (progress < 1) {
-        animationFrame = requestAnimationFrame(animate)
+    // 延迟一点时间后开始滚动，让用户先看到目标值
+    const timeout = setTimeout(() => {
+      if (!isHovered) {
+        startRolling()
       }
-    }
-
-    animationFrame = requestAnimationFrame(animate)
+    }, 1000)
 
     return () => {
-      if (animationFrame) {
-        cancelAnimationFrame(animationFrame)
-      }
+      clearTimeout(timeout)
+      stopRolling()
     }
-  }, [end, duration, isInView])
+  }, [isInView, end, isHovered, startRolling, stopRolling])
+
+  // 清理定时器
+  useEffect(() => {
+    return () => {
+      stopRolling()
+    }
+  }, [stopRolling])
 
   const formatNumber = (num: number) => {
     if (end >= 1000) {
@@ -61,12 +100,18 @@ export function AnimatedCounter({
   }
 
   return (
-    <motion.span 
+    <motion.span
       ref={ref}
-      className={className}
+      className={`${className} ${isHovered ? 'cursor-pointer' : ''}`}
       initial={{ opacity: 0, y: 20 }}
       animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{
+        transition: isHovered ? 'all 0.2s ease-out' : 'none',
+        transform: isHovered ? 'scale(1.02)' : 'scale(1)'
+      }}
     >
       {prefix}{formatNumber(count)}{suffix}
     </motion.span>

--- a/components/payment-demo.tsx
+++ b/components/payment-demo.tsx
@@ -242,7 +242,14 @@ function CashPaymentContent({
   const [isTargetAmountFocused, setIsTargetAmountFocused] = useState(false);
   // 处理基础货币输入变化，同时更新转换后的金额
   const onBaseAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value.trim() ? Number(event.target.value) : '';
+    const inputValue = event.target.value.trim();
+    const value = inputValue ? Number(inputValue) : '';
+    
+    // 检查是否为负数，如果是负数则不处理
+    if (value !== '' && typeof value === 'number' && value < 0) {
+      return;
+    }
+    
     onAmountChange(value);
 
     // 计算并更新转换后的金额
@@ -261,7 +268,13 @@ function CashPaymentContent({
 
   // 处理目标货币输入变化，根据目标货币金额反向计算基础货币金额
   const onTargetAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value.trim() ? Number(event.target.value) : '';
+    const inputValue = event.target.value.trim();
+    const value = inputValue ? Number(inputValue) : '';
+
+    // 检查是否为负数，如果是负数则不处理
+    if (value !== '' && typeof value === 'number' && value < 0) {
+      return;
+    }
 
     if (value === '' || value === 0) {
       onAmountChange('');
@@ -295,6 +308,7 @@ function CashPaymentContent({
               onFocus={() => setIsAmountFocused(true)}
               onBlur={() => setIsAmountFocused(false)}
               step="0.01"
+              min="0"
               value={amount}
               placeholder="0.00"
               title="Enter amount"
@@ -323,6 +337,7 @@ function CashPaymentContent({
                 value={convertedAmount}
                 placeholder="0.00"
                 step="0.01"
+                min="0"
                 onChange={onTargetAmountChange}
                 onFocus={() => setIsTargetAmountFocused(true)}
                 onBlur={() => setIsTargetAmountFocused(false)}

--- a/components/payment-demo.tsx
+++ b/components/payment-demo.tsx
@@ -288,7 +288,7 @@ function CashPaymentContent({
           <div className="flex-1">
             <input
               type="number"
-              className="w-full border rounded-l-lg border-r-0 h-14 font-semibold px-4"
+              className="w-full border rounded-l-lg border-r-0 h-14 font-semibold px-4 focus:outline-none focus:ring-0 focus:border-gray-300"
               onChange={onBaseAmountChange}
               step="0.01"
               value={amount}
@@ -315,7 +315,7 @@ function CashPaymentContent({
               </span>
               <input
                 type="number"
-                className="w-full border rounded-l-lg border-r-0 h-14 font-semibold pl-8 pr-4 focus:outline-none"
+                className="w-full border rounded-l-lg border-r-0 h-14 font-semibold pl-8 pr-4 focus:outline-none focus:ring-0 focus:border-gray-300"
                 value={convertedAmount}
                 placeholder="0.00"
                 step="0.01"

--- a/components/payment-demo.tsx
+++ b/components/payment-demo.tsx
@@ -238,6 +238,8 @@ function CashPaymentContent({
   onTargetCurrencyChange: (value: string) => void;
   onConvertedAmountChange: (value: number | '') => void;
 }) {
+  const [isAmountFocused, setIsAmountFocused] = useState(false);
+  const [isTargetAmountFocused, setIsTargetAmountFocused] = useState(false);
   // 处理基础货币输入变化，同时更新转换后的金额
   const onBaseAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value.trim() ? Number(event.target.value) : '';
@@ -288,8 +290,10 @@ function CashPaymentContent({
           <div className="flex-1">
             <input
               type="number"
-              className="w-full border rounded-l-lg border-r-0 h-14 font-semibold px-4 focus:outline-none focus:ring-0 focus:border-gray-300"
+              className="w-full border rounded-l-lg border-r-0 h-14 font-semibold px-4"
               onChange={onBaseAmountChange}
+              onFocus={() => setIsAmountFocused(true)}
+              onBlur={() => setIsAmountFocused(false)}
               step="0.01"
               value={amount}
               placeholder="0.00"
@@ -298,7 +302,7 @@ function CashPaymentContent({
           </div>
           <div className="w-32 flex-shrink-0">
             <MyCombobox
-              className="rounded-r-lg h-14 w-full"
+              className={`rounded-r-lg h-14 w-full ${isAmountFocused ? 'ring-2 ring-blue-500' : ''}`}
               options={CurrencyList.map(c => ({ icon: c.icon, label: c.code, value: c.code }))}
               onChange={onCurrencyChange}
               value={currency}
@@ -315,16 +319,18 @@ function CashPaymentContent({
               </span>
               <input
                 type="number"
-                className="w-full border rounded-l-lg border-r-0 h-14 font-semibold pl-8 pr-4 focus:outline-none focus:ring-0 focus:border-gray-300"
+                className="w-full border rounded-l-lg border-r-0 h-14 font-semibold pl-8 pr-4"
                 value={convertedAmount}
                 placeholder="0.00"
                 step="0.01"
                 onChange={onTargetAmountChange}
+                onFocus={() => setIsTargetAmountFocused(true)}
+                onBlur={() => setIsTargetAmountFocused(false)}
               />
             </div>
             <div className="w-32 flex-shrink-0">
               <MyCombobox
-                className="rounded-r-lg h-14 w-full"
+                className={`rounded-r-lg h-14 w-full ${isTargetAmountFocused ? 'ring-2 ring-blue-500' : ''}`}
                 options={CurrencyList.map(c => ({ icon: c.icon, label: c.code, value: c.code }))}
                 onChange={onTargetCurrencyChange}
                 value={targetCurrency}

--- a/components/payment-demo.tsx
+++ b/components/payment-demo.tsx
@@ -40,7 +40,7 @@ const fiatExchangeRates: Record<string, number> = {
 export default function PaymentDemo() {
   const [donationType, setDonationType] = useState<'crypto' | 'cash'>('crypto');
   const [paymentMethod, setPaymentMethod] = useState(paymentMethods[0].value);
-  const [dollar, setDollar] = useState(1);
+  const [dollar, setDollar] = useState<number | ''>(1);
   const [currency, setCurrency] = useState<string>('USD');
   const [targetCurrency, setTargetCurrency] = useState<string>('CNY');
   const [amount, setAmount] = useState<number | ''>(1);
@@ -48,25 +48,33 @@ export default function PaymentDemo() {
 
   function onAmountChange(event: ChangeEvent<HTMLInputElement>) {
     const input = event.target as HTMLInputElement;
-    const value = input.value ? Number(input.value) : 0;
+    const value = input.value.trim() ? Number(input.value) : '';
     setAmount(value);
 
     // 根据当前支付方式和汇率计算美元价值
-    const rate = exchangeRates[paymentMethod as keyof typeof exchangeRates];
-    const dollarValue = value * rate;
-    setDollar(Number(dollarValue.toFixed(2)));
+    if (value !== '' && typeof value === 'number') {
+      const rate = exchangeRates[paymentMethod as keyof typeof exchangeRates];
+      const dollarValue = value * rate;
+      setDollar(Number(dollarValue.toFixed(2)));
+    } else {
+      setDollar('');
+    }
   }
 
   // update crypto amount based on dollar and payment method
   function onDollarChange(event: ChangeEvent<HTMLInputElement>) {
     const input = event.target as HTMLInputElement;
-    const value = input.value ? Number(input.value) : 0;
+    const value = input.value.trim() ? Number(input.value) : '';
     setDollar(value);
 
     // 根据当前支付方式和汇率计算加密货币数量
-    const rate = exchangeRates[paymentMethod as keyof typeof exchangeRates];
-    const cryptoAmount = value / rate;
-    setAmount(Number(cryptoAmount.toFixed(6)));
+    if (value !== '' && typeof value === 'number') {
+      const rate = exchangeRates[paymentMethod as keyof typeof exchangeRates];
+      const cryptoAmount = value / rate;
+      setAmount(Number(cryptoAmount.toFixed(6)));
+    } else {
+      setAmount('');
+    }
   }
 
   // 当支付方式改变时，重新计算金额
@@ -157,7 +165,7 @@ function CryptoPaymentContent({
 }: {
   paymentMethod: string;
   amount: number | '';
-  dollar: number;
+  dollar: number | '';
   onPaymentMethodChange: (value: string) => void;
   onAmountChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onDollarChange: (event: ChangeEvent<HTMLInputElement>) => void;


### PR DESCRIPTION
Improved some UI in the landing page

## Main changes

### remove unneeded padding to make page wider

before:

<img width="1698" height="705" alt="image" src="https://github.com/user-attachments/assets/ec7e7ed3-9a52-4fe2-a535-ee92a9edf469" />

after:

<img width="1736" height="1086" alt="image" src="https://github.com/user-attachments/assets/04ef36d2-8951-4814-a4a0-5618af5b5df8" />

### highlight whole component on input

before:

<img width="539" height="467" alt="image" src="https://github.com/user-attachments/assets/d9a316f0-5cc5-4835-8cbb-7e5f2e79771a" />

after:

<img width="546" height="492" alt="image" src="https://github.com/user-attachments/assets/5d3e704c-db76-4d68-8655-ec78cf1e8d2a" />

### not reuse site-footer in landing page

before:

<img width="1489" height="807" alt="image" src="https://github.com/user-attachments/assets/15716fa1-16c2-4c5a-a447-48bcd9a95173" />

after:

<img width="1569" height="702" alt="image" src="https://github.com/user-attachments/assets/c20e071f-5193-42a3-b330-e58e008d4d99" />

### text in showcase section is not visible

before:

<img width="1234" height="622" alt="image" src="https://github.com/user-attachments/assets/72bddc76-8d9c-4df2-95c6-385f06b6dda2" />

after:

<img width="1408" height="571" alt="image" src="https://github.com/user-attachments/assets/a82b6b2f-85de-4bca-9d73-99f392b25046" />

### numbers in dashboard section move forever

before:

<img width="1179" height="693" alt="image" src="https://github.com/user-attachments/assets/a33341cf-c127-41c1-b96f-24467f52c00d" />

after:

<img width="1354" height="714" alt="image" src="https://github.com/user-attachments/assets/e8f80ccd-2c52-4457-9eca-028e1f874371" />

