### PR TITLE
send email after donation or refund

### DIFF
--- a/__tests__/send-email.test.ts
+++ b/__tests__/send-email.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { getDonationProps } from '@/lib/send-email';
+import { ProjectInfo } from "@/types";
+
+describe('Test Send Email', () => {
+    describe('sendDonationEmail', () => {
+        it('should construct send donation email props', () => {
+            const projectDetail: ProjectInfo = {
+                accepts: '1',
+                backers: '7',
+                banner: 'https://assets.intuipay.xyz/projects/images/1751303115029-1.webp.webp',
+                banners: '["https://assets.intuipay.xyz/intuipay-demo.webp"]',
+                campaign: 'This is an awesome project.\'<--! separator -->\'No risk this time!',
+                category: '1',
+                email: '',
+                end_at: '2025-10-01 00:00:00',
+                github: '',
+                id: '120002',
+                location: 'China',
+                org_contact: 'China',
+                org_description: 'Intuipay is great.',
+                org_email: '',
+                org_location: 'China mainland',
+                org_logo: 'https://intuipay.xyz/images/logo.svg',
+                org_name: 'Intuipay',
+                org_networks: '["ethereum-sepolia", "solana-devnet", "pharos-testnet"]',
+                org_slug: 'intuipay',
+                org_social_links: '{}',
+                org_title: '',
+                org_tokens: '{"ethereum-sepolia": ["eth", "usdc"], "pharos-testnet": ["phrs", "usdc"], "solana-devnet": ["sol", "usdc"]}',
+                org_type: '1',
+                org_wallets: '{"ethereum-sepolia": "0xE62868F9Ae622aa11aff94DB30091B9De20AEf86", "pharos-testnet": "0xfFe4b50BC2885e4708544477B6EeD4B32e4d82BF", "solana-devnet": "Ft7m7qrY3spLNKo6aMAHMArAT3oLSSy4DnJ3y3SF1DP1"}',
+                org_website: 'https://intuipay.xyz/',
+                project_name: 'Intuipay 2nd demo',
+                project_subtitle: 'Another great project',
+                rewards: '[{"address": null, "amount": 1, "count": null, "description": "Everyone will get this", "destinations": null, "id": 1, "image": "https://assets.intuipay.xyz/dr-zaiton-sameon.webp", "month": null, "number": 0, "ship_method": 3, "title": "One time reward", "year": null}, {"address": "Guangzhou, China", "amount": 2, "count": null, "description": "Tier 1 with time limit", "destinations": null, "id": 2, "image": "https://assets.intuipay.xyz/dr-noraini-binti-syed.webp", "month": 8, "number": 100, "ship_method": 2, "title": "Tier 1", "year": 2025}, {"address": null, "amount": 3, "count": null, "description": "Tier 2 without time limit", "destinations": [{"cost": 100, "country": "China"}], "id": 3, "image": "https://assets.intuipay.xyz/sarah-chen-wei-lin.webp", "month": null, "number": 20, "ship_method": 1, "title": "Tier 2", "year": null}]',
+                social_links: '{"discord": "", "facebook": "", "github": "", "instagram": "", "linkedin": "", "reddit": "", "telegram": "", "twitter": "", "website": "https://intuipay.xyz", "youtube": ""}',
+                status: '10',
+                tags: '["intuipay"]',
+                website: '',
+                amount: 40300,
+                goal_amount: 10000000,
+                type: 101,
+                project_slug: 'intuipay-2nd-demo',
+                campaign_id: undefined,
+                networks: ['ethereum-sepolia'],
+                tokens: { 'ethereum- sepolia': ['usdc'] },
+                wallets: {
+                    'ethereum-sepolia': '0xbDE5c24B7c8551f93B95a8f27C6d926B3bCcF5aD'
+                }
+            };
+
+            // 测试捐款 1 USDC
+            const donationInfo = { id: 1560001, "address1": "beijing", "address2": "haidian", "dollar": 1, "city": "beijing", "company_name": "", "country": "China", "currency": "usdc", "email": "joey.xf@gmail.com", "first_name": "joey", "has_tax_invoice": 0, "is_anonymous": 0, "last_name": "xie", "network": "ethereum-sepolia", "note": "keep the greate work", "project_id": "120002", "state": "Beijing", "wallet": "metamask", "zip": "100001", "amount": "1000000", "account": "", "method": 1, "status": 3, "tx_hash": "0x6fcc7abe58c6323e4e05f403fc2cbc837f5909aede2c1bae18bbe5aca18cbc25", "wallet_address": "0x7e727520B29773e7F23a8665649197aAf064CeF1", "project_slug": "intuipay-2nd-demo", "reward_id": "1" };
+
+            const donateProps = getDonationProps(projectDetail, donationInfo);
+
+            // console.log('donate props', donateProps);
+
+            expect(donateProps).toEqual({
+                to: 'joey.xf@gmail.com',
+                amount: '1000000',
+                creator: 'Intuipay',
+                currency: 'usdc',
+                deliveryMethod: 'Digital delivery',
+                deliveryTime: 'To be determined',
+                reward: 'reward name',
+                dollar: 1,
+                endAt: '2025-10-01 00:00:00',
+                from: 'Intuipay',
+                id: 1560001,
+                index: 1560001,
+                projectName: 'Intuipay 2nd demo',
+                status: 'successful',
+                txHash: '0x6fcc7abe58c6323e4e05f403fc2cbc837f5909aede2c1bae18bbe5aca18cbc25'
+            });
+        });
+    })
+});

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -193,7 +193,7 @@ export default function DonationStep4({
         address: recipientAddress as `0x${string}`,
         abi: crowdFundingABI,
         functionName: 'contributeERC20',
-        args: [project.campaign_id, amount],
+        args: [project.campaign_id ?? 1, amount],
       });
     } catch (e) {
       setMessage(getReadableErrorMessage(e));
@@ -317,7 +317,7 @@ export default function DonationStep4({
           address: recipientAddress as `0x${string}`,
           abi: crowdFundingABI,
           functionName: 'contribute',
-          args: [project.campaign_id], // campaignId, 1 is the default campaign ID
+          args: [project.campaign_id ?? 1], // campaignId, 1 is the default campaign ID
           value: amount,
         });
       } else if (currencyNetworkConfig?.contractAddress) {

--- a/app/api/refund/route.ts
+++ b/app/api/refund/route.ts
@@ -1,6 +1,8 @@
 import { fetchTidb } from '@/services/fetch-tidb';
 import { auth } from '@/lib/auth';
 import { headers } from 'next/headers';
+import { getRefundProps, sendRefundEmail } from '@/lib/send-email';
+import { getProjectDetail } from '@/lib/data';
 
 export const runtime = 'edge';
 
@@ -22,8 +24,43 @@ export async function POST(req: Request) {
   }
   json.user_id = user_id;
 
+  const project = await getProjectDetail(json.project_id);
+  if (!project) {
+    return new Response(
+        JSON.stringify({
+          code: 1,
+          message: `Failed to fetch project ${json.project_id}`,
+        }),
+        { status: 400 },
+      );
+  }
+  
+
   const data = await fetchTidb<{ last_insert_id: number }>('/refund', 'POST', json);
   console.log('save refund result', data);
+
+  // send refund email
+  let finalEmail = '';
+  if (session?.user.email) {
+    finalEmail = session.user.email;
+  }
+  // 如果邮箱不为空，发送捐款成功邮件
+  if (finalEmail && finalEmail.trim()) {
+    try {
+      // 构建发送邮件所需的参数
+      const emailParams = getRefundProps(project, {
+        to: finalEmail,
+        tx_hash: json.tx_hash,
+        wallet_address: json.wallet_address,
+      });
+      await sendRefundEmail(emailParams);
+      console.log('Refund email sent successfully to:', finalEmail);
+    } catch (emailError) {
+      // 邮件发送失败不影响捐款流程，只记录错误
+      console.error('Failed to send donation email:', emailError);
+    }
+  }
+
   return new Response(
     JSON.stringify({
       code: 0,

--- a/app/donate/[...slug]/page.tsx
+++ b/app/donate/[...slug]/page.tsx
@@ -50,8 +50,10 @@ export default async function DonatePage({
   if (!project) {
     return notFound();
   }
+  console.log('project', slug, project);
 
   const projectDetail = await getProjectDetail(slug);
+  console.log('Project Detail:', projectDetail, slug);
   if (!projectDetail) {
     return notFound();
   }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -120,6 +120,7 @@ export const getProjectDetail = cache(async function getProjectDetail(
     searchParams.set('slug', slug);
   }
   const data = await fetchTidb<ProjectInfo>(`/project_detailed?${searchParams.toString()}`);
+  console.log('getProjectDetail data:', data);
   if (data.length === 0) {
     return null;
   }

--- a/lib/send-email.ts
+++ b/lib/send-email.ts
@@ -1,0 +1,121 @@
+import { DonationInfo, ProjectInfo, Reward } from "@/types";
+
+type BaseProps = {
+  to: string;
+}
+
+type DonationProps = BaseProps & {
+  amount: number;
+  creator: string;
+  currency: string;
+  deliveryMethod: string;
+  deliveryTime: string;
+  dollar: number;
+  endAt: string;
+  from: string;
+  id: number;
+  index: number;
+  projectName: string;
+  reward: string;
+  status: string;
+  txHash: string;
+}
+
+/**
+ * 发送捐款成功邮件
+ * @param params 邮件参数
+ */
+export async function sendDonationEmail(params: DonationProps) {
+  try {
+    const res = await fetch('https://resend.intuipay.xyz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'donated',
+        ...params,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to send donation email: ${res.status}`);
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('sendDonationEmail error:', err);
+    return null;
+  }
+}
+
+export function getDonationProps(project: ProjectInfo, donation: DonationInfo): DonationProps {
+  let reward: Reward | null = null;
+  if (donation.reward_id && project.rewards) {
+    reward = getRewardById(donation.reward_id, project.rewards);
+  }
+  return {
+    to: donation.email,
+    amount: donation.amount as number, // 这里的 amount 是 string 类型，不能转为number，因为数字很大，所以使用 as 愚弄一下编译器
+    creator: project.org_name,
+    currency: donation.currency,
+    deliveryMethod: reward && reward.shipping_method ? reward.shipping_method : 'Digital delivery',
+    deliveryTime: reward && reward.estimated_delivery ? reward.estimated_delivery : 'To be determined',
+    reward: reward ? reward.name : 'reward name',
+    dollar: donation.dollar || 0,
+    endAt: project.end_at,
+    from: project.org_name,
+    id: donation.id,
+    index: donation.id,
+    projectName: project.project_name,
+    status: "successful",
+    txHash: donation.tx_hash || '',
+  };
+}
+
+function getRewardById(rewardId: number, rewardsString: string): Reward | null {
+  const rawRewards = JSON.parse(rewardsString);
+
+  // 映射 ship_method 数字到描述
+  const getShippingMethod = (shipMethod: number): string => {
+    switch (shipMethod) {
+      case 1: return 'By myself';
+      case 2: return 'Local pickup';
+      case 3: return 'Digital delivery';
+      default: return 'Digital delivery';
+    }
+  };
+
+  // 格式化预计交付时间
+  const getEstimatedDelivery = (month: number | null, year: number | null): string => {
+    if (month && year) {
+      const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      return `${monthNames[month - 1]} ${year}`;
+    }
+    return 'TBD';
+  };
+
+  // 格式化可用性信息
+  // number: 总量, count: 剩余数量
+  const getAvailability = (number: number, count: number | null): string => {
+    if (number === 0) return 'Unlimited';
+    if (count !== null) return `Limited (${count} left of ${number})`;
+    return `Limited (${number} available)`;
+  };
+
+  // 查找匹配的奖励
+  const targetReward = rawRewards.find((reward: any) => reward.id === rewardId);
+
+  if (!targetReward) {
+    return null;
+  }
+
+  // 转换为 Reward 格式
+  return {
+    id: targetReward.id.toString(),
+    name: targetReward.title || 'Untitled Reward',
+    description: targetReward.description || 'No description available',
+    amount: targetReward.amount || 0,
+    shipping_method: getShippingMethod(targetReward.ship_method),
+    estimated_delivery: getEstimatedDelivery(targetReward.month, targetReward.year),
+    availability: getAvailability(targetReward.number, targetReward.count),
+    image: targetReward.image || '', // 确保有图片字段
+  };
+}

--- a/lib/send-email.ts
+++ b/lib/send-email.ts
@@ -119,3 +119,45 @@ function getRewardById(rewardId: number, rewardsString: string): Reward | null {
     image: targetReward.image || '', // 确保有图片字段
   };
 }
+
+type RefundProps = BaseProps & {
+  amount: number;
+  hashId: string;
+  projectName: string;
+  to: string;
+  wallet: string;
+}
+
+export async function sendRefundEmail(params: RefundProps) {
+  try {
+    const res = await fetch('https://resend.intuipay.xyz', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: 'donated',
+        ...params,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to send donation email: ${res.status}`);
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('sendDonationEmail error:', err);
+    return null;
+  }
+}
+
+export function getRefundProps(project: ProjectInfo, refundInfo: {
+  tx_hash: string;
+  wallet_address: string;
+  to: string;
+}): RefundProps {
+  return {
+    amount: 1, // TODO: 查询数据库获取退款金额
+    hashId: refundInfo.tx_hash,
+    projectName: project.project_name,
+    to: refundInfo.to,
+    wallet: refundInfo.wallet_address, 
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -84,11 +84,13 @@ export type DonationInfo = {
   state: string;
   wallet: string;
   zip: string;
+  tx_hash: string;
 
   // 奖励相关字段
   selected_reward?: Reward | null;
   has_selected_reward?: boolean;
   pledge_without_reward?: boolean;
+  reward_id?: number;
 
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
在捐款和退款后，给用户发邮件。首选用户填的信息里的邮箱，如果没填，则再使用 profile 里的邮箱

## 截图

<img width="1308" height="1324" alt="image" src="https://github.com/user-attachments/assets/7bcee70f-296d-434d-8e47-e999e0b1e964" />

提交的参数：

```json
{"address1":"china","address2":"shanghai","dollar":1,"city":"huangpu","company_name":"","country":"china","currency":"usdc","email":"joey.xf@gmail.com","first_name":"joey","has_tax_invoice":0,"is_anonymous":0,"last_name":"xie","network":"ethereum-sepolia","note":"nothing matter","project_id":"120002","state":"shanghai","wallet":"metamask","zip":"10000","amount":"1000000","account":"","method":1,"status":3,"tx_hash":"0x55f7631358674a382f8d9c10b78301c9d8fdcdeb9c37e5a72c35ce66cd8f0e35","wallet_address":"0x7e727520B29773e7F23a8665649197aAf064CeF1","project_slug":"intuipay-2nd-demo","reward_id":"1"}
```

## 问题

- [ ] transaction id 不显示，实际传了 1590001
- [ ] donate 邮件里的 index 是什么意思？现在传的也是 donationId
- [ ] 邮件里的 amount 显示有误，我传的是 1000000 对应 1 USDC
- [ ] 退款邮件里的 amount，需要走额外的接口获取，现在缺少查询退款信息的接口
