### PR TITLE
fix filter drawer duplicate key error

### DIFF
--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -24,15 +24,12 @@ const Slider = React.forwardRef<
         <SliderPrimitive.Range className="absolute h-full bg-primary" />
       </SliderPrimitive.Track>
       {Array.from({ length: thumbs }).map((_, index) => (
-        <>
-          <SliderPrimitive.Thumb
-            key={index}
-            className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-          />
-          <div className="absolute left-1" style={{ transform: `translate(${Number(props.value?.[ index ] ?? 0) * 3.5}px, -1.5rem)` }} key={index}>
+        <React.Fragment key={index}>
+          <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+          <div className="absolute left-1" style={{ transform: `translate(${Number(props.value?.[ index ] ?? 0) * 3.5}px, -1.5rem)` }}>
             {props.value?.[ index ] ?? 0}%
           </div>
-        </>
+        </React.Fragment>
       ))}
     </SliderPrimitive.Root>
   )

--- a/data/index.ts
+++ b/data/index.ts
@@ -473,13 +473,13 @@ export enum ProjectCategories {
   'International Development' = 18,
   'Legal Support' = 19,
   'LGBTQ' = 20,
-  'Media' = 21,
   'Racial Justice' = 21,
   'Religion and Faith Based' = 22,
   'Technology' = 23,
   'Water & Hygiene' = 24,
   'Women & Girls' = 25,
   'Agriculture' = 26,
+  Other = 255,
 }
 
 export enum ProjectDonationMethods {


### PR DESCRIPTION
测 marketplace 项目列表时，点击 filter 按钮，偶然发现的错误

1. `ProjectCategories` 里有2个 21的key，参考 dashboard 删掉了 Media，补充了 Other: 255
2. 在 FilterDrawer 用到的 Slider 组件，thumbs 传的是2，因为 `<></>` 会将组件平铺，导致 index =0, index = 1 多出现一次，所以改为用 `React.Fragment` 打包为一个整体