### PR TITLE
fix widget and profile UI

### DIFF
--- a/app/_components/crowdfunding/donate-page.tsx
+++ b/app/_components/crowdfunding/donate-page.tsx
@@ -187,13 +187,13 @@ export default function DonationPageComp({
         } as React.CSSProperties}
       >
         {/* Hero Image */}
-        <div className="relative w-full aspect-[3/1] rounded-lg mb-4">
+        <div className="relative w-full aspect-[3/1] rounded-lg mb-4 overflow-hidden">
           {projectInfo.banner
             ? <Image
                 src={projectInfo.banner}
                 alt={projectInfo.project_name}
                 fill
-                className="object-contain object-center"
+                className="object-cover object-center"
                 priority
                 />
             : <div className="w-full h-full bg-gray-100 flex items-center justify-center text-2xl font-bold text-black/50">

--- a/app/_components/crowdfunding/donate-page.tsx
+++ b/app/_components/crowdfunding/donate-page.tsx
@@ -301,7 +301,7 @@ export default function DonationPageComp({
 
             {/* Complete Step */}
             {currentStep === 'complete' && <DonationStep5
-              index={info.id}
+              index={info.index || 1}
               reset={resetForm}
               project={projectInfo}
               info={info}

--- a/app/_components/crowdfunding/step1.tsx
+++ b/app/_components/crowdfunding/step1.tsx
@@ -8,7 +8,7 @@ import { ChangeEvent, useState, useEffect, FormEvent, useCallback, useRef } from
 import CtaFooter from '@/app/_components/donate/cta-footer';
 import { clsx } from 'clsx';
 import Image from 'next/image';
-import { ArrowLeft, AlertCircle } from 'lucide-react';
+import { ArrowLeftIcon, WarningCircleIcon } from '@phosphor-icons/react';
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain } from 'wagmi';
 import { useMultiWalletBalance } from '@/hooks/use-multi-wallet-balance';
 import {
@@ -531,7 +531,7 @@ export default function DonationStep1({
           <Popover>
             <PopoverTrigger asChild>
               <button className="flex items-center gap-1 text-blue-600 hover:text-blue-700 transition-colors">
-                <AlertCircle className="h-4 w-4" />
+                <WarningCircleIcon className="h-4 w-4" />
                 <span className="text-sm underline cursor-pointer">
                   Rewards aren't guaranteed
                 </span>
@@ -597,7 +597,7 @@ export default function DonationStep1({
             onClick={handleGoBackToRewards}
             className="absolute left-0 hidden sm:block"
           >
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeftIcon className="h-5 w-5" />
           </button>
           <h2 className="text-xl font-semibold text-center text-black">
             {project.project_cta || 'Make your pledge today'}

--- a/app/_components/crowdfunding/step1.tsx
+++ b/app/_components/crowdfunding/step1.tsx
@@ -1,13 +1,14 @@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import MyCombobox from '@/components/my-combobox';
 import { DropdownItemProps } from '@/types';
 import { ChangeEvent, useState, useEffect, FormEvent, useCallback, useRef } from 'react';
 import CtaFooter from '@/app/_components/donate/cta-footer';
 import { clsx } from 'clsx';
 import Image from 'next/image';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, AlertCircle } from 'lucide-react';
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain } from 'wagmi';
 import { useMultiWalletBalance } from '@/hooks/use-multi-wallet-balance';
 import {
@@ -526,10 +527,33 @@ export default function DonationStep1({
           ))}
         </div>
         
-        <div className="text-right">
-          <span className="text-blue-600 underline text-sm cursor-pointer">
-            Rewards aren't guaranteed
-          </span>
+        <div className="flex items-center justify-end gap-1">
+          <Popover>
+            <PopoverTrigger asChild>
+              <button className="flex items-center gap-1 text-blue-600 hover:text-blue-700 transition-colors">
+                <AlertCircle className="h-4 w-4" />
+                <span className="text-sm underline cursor-pointer">
+                  Rewards aren't guaranteed
+                </span>
+              </button>
+            </PopoverTrigger>
+            <PopoverContent 
+              align="end" 
+              side="top"
+              sideOffset={8}
+              className="w-80 bg-black/80 text-white border-none p-3 rounded-lg"
+            >
+              <p className="text-xs leading-4 text-center">
+                While the creator agrees to use best endeavors to deliver the reward to you, please note that your 
+                receipt of the reward is not guaranteed and will depend on the nature and development of the 
+                project. Your receipt of the reward is also subject to any additional terms and requirements 
+                specified by creator, and your fulfillment of any requirements specified by the creator.
+              </p>
+              <div
+                className="absolute top-full right-6 w-0 h-0 border-l-[8px] border-r-[8px] border-t-[8px] border-l-transparent border-r-transparent border-t-black/80"
+              />
+            </PopoverContent>
+          </Popover>
         </div>
         
         {/* 继续按钮 */}

--- a/app/_components/crowdfunding/step2.tsx
+++ b/app/_components/crowdfunding/step2.tsx
@@ -257,7 +257,7 @@ export default function DonationStep2({
             onCheckedChange={(checked) => setIsAnonymous(checked as boolean)}
           />
           <Label htmlFor="anonymous" className="text-sm font-medium">
-            Make my donation anonymous
+            Make my pledge anonymous
           </Label>
         </div>
       </CtaFooter>

--- a/app/_components/crowdfunding/step2.tsx
+++ b/app/_components/crowdfunding/step2.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeftIcon } from '@phosphor-icons/react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import { DonationInfo, ShipInfo } from '@/types';
 import { Textarea } from '@/components/ui/textarea';
@@ -101,7 +100,7 @@ export default function DonationStep2({
             onClick={goToPreviousStep}
             className="absolute left-0 hidden sm:block"
           >
-            <ArrowLeft className="h-5 w-5" />
+            <ArrowLeftIcon className="h-5 w-5" />
           </button>
           <h1 className="text-xl font-semibold text-center text-gray-900">Leave your contact information</h1>
         </div>
@@ -326,7 +325,7 @@ export default function DonationStep2({
           onClick={handleGoBackToContact}
           className="absolute left-0 hidden sm:block"
         >
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeftIcon className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-semibold text-center text-gray-900">Your shipping address</h1>
       </div>

--- a/app/_components/crowdfunding/step2.tsx
+++ b/app/_components/crowdfunding/step2.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { FormEvent, useEffect, useRef, useState } from 'react';
-import { DonationInfo } from '@/types';
+import { DonationInfo, ShipInfo } from '@/types';
 import { Textarea } from '@/components/ui/textarea';
 import CtaFooter from '@/app/_components/donate/cta-footer';
 
@@ -42,21 +42,25 @@ export default function DonationStep2({
   // 处理"Same as contact address"功能
   const handleSameAsContact = (checked: boolean) => {
     setInfo({ same_as_contact: checked });
-    
+
     if (checked) {
       // 复制联系信息到收货地址
       const shippingName = isCompany ? info.company_name : `${info.first_name || ''} ${info.last_name || ''}`.trim();
-      
+
+      const shipInfo: ShipInfo = {
+        name: shippingName || '',
+        address1: info.address1 || '',
+        address2: info.address2 || '',
+        country: info.country || '',
+        state: info.state || '',
+        city: info.city || '',
+        zip: info.zip || '',
+        email: info.email || '',
+        phone: '',
+      };
+
       setInfo({
-        shipping_name: shippingName,
-        shipping_address1: info.address1,
-        shipping_address2: info.address2,
-        shipping_country: info.country,
-        shipping_state: info.state,
-        shipping_city: info.city,
-        shipping_zip: info.zip,
-        contact_email: info.email,
-        contact_phone: info.contact_phone || '',
+        ship_info: shipInfo,
       });
     }
   };
@@ -102,190 +106,190 @@ export default function DonationStep2({
           <h1 className="text-xl font-semibold text-center text-gray-900">Leave your contact information</h1>
         </div>
 
-      {/* Company/Institution Checkbox */}
-      <div className="flex items-center space-x-3">
-        <Checkbox
-          id="company"
-          checked={isCompany}
-          disabled={isAnonymous}
-          onCheckedChange={(checked) => setIsCompany(checked as boolean)}
-        />
-        <Label htmlFor="company" className="text-sm font-semibold">
-          Company / Institution
-        </Label>
-      </div>
-
-      {isCompany ? <div className="space-y-2">
-        <Label htmlFor="company-name" className="text-sm font-semibold text-black/50">
-          Company / Institution name
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="company-name"
-          name="company"
-          onChange={event => setInfo({ company_name: event.target.value })}
-          placeholder="Company / Institution Name *"
-          required={!isAnonymous}
-          value={info.company_name}
-        />
-      </div> : <div className="grid grid-cols-2 gap-2">
-        <Label htmlFor="first-name" className="text-sm font-semibold text-black/50">
-          First Name
-        </Label>
-        <Label htmlFor="last-name" className="text-sm font-semibold text-black/50">
-          Last Name
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="first-name"
-          name="first-name"
-          onChange={event => setInfo({ first_name: event.target.value })}
-          placeholder="First name *"
-          required={!isAnonymous}
-          value={info.first_name}
-        />
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="last-name"
-          name="last-name"
-          onChange={event => setInfo({ last_name: event.target.value })}
-          placeholder="Last name *"
-          required={!isAnonymous}
-          value={info.last_name}
-        />
-      </div>}
-
-      {/* Address Fields */}
-      <div className="space-y-2">
-        <Label htmlFor="address1" className="text-sm font-semibold text-black/50">
-          Address
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="address1"
-          name="address1"
-          onChange={event => setInfo({ address1: event.target.value })}
-          placeholder="Line 1*"
-          required={!isAnonymous}
-          value={info.address1}
-        />
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="address2"
-          name="address2"
-          onChange={event => setInfo({ address2: event.target.value })}
-          placeholder="Line 2"
-          value={info.address2}
-        />
-      </div>
-
-      {/* Country and State */}
-      <div className="grid grid-cols-2 gap-2">
-        <Label htmlFor="country" className="text-sm font-semibold text-black/50">
-          Country
-        </Label>
-        <Label htmlFor="state" className="text-sm font-semibold text-black/50">
-          State
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="country"
-          name="country"
-          onChange={event => setInfo({ country: event.target.value })}
-          placeholder="Country *"
-          required={!isAnonymous}
-          value={info.country}
-        />
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="state"
-          name="state"
-          onChange={event => setInfo({ state: event.target.value })}
-          placeholder="State *"
-          required={!isAnonymous}
-          value={info.state}
-        />
-      </div>
-
-      {/* City and Zip */}
-      <div className="grid grid-cols-2 gap-2">
-        <Label htmlFor="city" className="text-sm font-semibold text-black/50">
-          City
-        </Label>
-        <Label htmlFor="zip-code" className="text-sm font-semibold text-black/50">
-          Zip Code
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="city"
-          name="city"
-          onChange={event => setInfo({ city: event.target.value })}
-          placeholder="City *"
-          required={!isAnonymous}
-          value={info.city}
-        />
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          disabled={isAnonymous}
-          id="zip-code"
-          name="zip-code"
-          onChange={event => setInfo({ zip: event.target.value })}
-          placeholder="Zip code *"
-          required={!isAnonymous}
-          value={info.zip}
-        />
-      </div>
-
-      {/* Email */}
-      <div className="space-y-2">
-        <Label htmlFor="email" className="text-sm font-semibold text-black/50">
-          Email Address
-        </Label>
-        <Input
-          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          id="email"
-          name="email"
-          onChange={event => setInfo({ email: event.target.value })}
-          placeholder={`Email address${isAnonymous ? '' : ' *'}`}
-          required={!isAnonymous}
-          type="email"
-          value={info.email}
-        />
-        <div className="flex items-center gap-2">
+        {/* Company/Institution Checkbox */}
+        <div className="flex items-center space-x-3">
           <Checkbox
-            id="tax-invoice"
-            checked={info.has_tax_invoice}
+            id="company"
+            checked={isCompany}
             disabled={isAnonymous}
-            onCheckedChange={(checked) => setInfo({ has_tax_invoice: checked as boolean })}
+            onCheckedChange={(checked) => setIsCompany(checked as boolean)}
           />
-          <Label htmlFor="tax-invoice" className="text-sm font-medium text-black/50">
-            Send me the tax invoice
+          <Label htmlFor="company" className="text-sm font-semibold">
+            Company / Institution
           </Label>
         </div>
-      </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="note" className="text-sm font-semibold text-black/50">
-          Leave a note
-        </Label>
-        <Textarea
-          className="h-30 border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
-          id="note"
-          name="note"
-          onChange={event => setInfo({ note: event.target.value })}
-          placeholder="Note"
-          value={info.note}
-          rows={5}
-        />
-      </div>
+        {isCompany ? <div className="space-y-2">
+          <Label htmlFor="company-name" className="text-sm font-semibold text-black/50">
+            Company / Institution name
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="company-name"
+            name="company"
+            onChange={event => setInfo({ company_name: event.target.value })}
+            placeholder="Company / Institution Name *"
+            required={!isAnonymous}
+            value={info.company_name}
+          />
+        </div> : <div className="grid grid-cols-2 gap-2">
+          <Label htmlFor="first-name" className="text-sm font-semibold text-black/50">
+            First Name
+          </Label>
+          <Label htmlFor="last-name" className="text-sm font-semibold text-black/50">
+            Last Name
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="first-name"
+            name="first-name"
+            onChange={event => setInfo({ first_name: event.target.value })}
+            placeholder="First name *"
+            required={!isAnonymous}
+            value={info.first_name}
+          />
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="last-name"
+            name="last-name"
+            onChange={event => setInfo({ last_name: event.target.value })}
+            placeholder="Last name *"
+            required={!isAnonymous}
+            value={info.last_name}
+          />
+        </div>}
+
+        {/* Address Fields */}
+        <div className="space-y-2">
+          <Label htmlFor="address1" className="text-sm font-semibold text-black/50">
+            Address
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="address1"
+            name="address1"
+            onChange={event => setInfo({ address1: event.target.value })}
+            placeholder="Line 1*"
+            required={!isAnonymous}
+            value={info.address1}
+          />
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="address2"
+            name="address2"
+            onChange={event => setInfo({ address2: event.target.value })}
+            placeholder="Line 2"
+            value={info.address2}
+          />
+        </div>
+
+        {/* Country and State */}
+        <div className="grid grid-cols-2 gap-2">
+          <Label htmlFor="country" className="text-sm font-semibold text-black/50">
+            Country
+          </Label>
+          <Label htmlFor="state" className="text-sm font-semibold text-black/50">
+            State
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="country"
+            name="country"
+            onChange={event => setInfo({ country: event.target.value })}
+            placeholder="Country *"
+            required={!isAnonymous}
+            value={info.country}
+          />
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="state"
+            name="state"
+            onChange={event => setInfo({ state: event.target.value })}
+            placeholder="State *"
+            required={!isAnonymous}
+            value={info.state}
+          />
+        </div>
+
+        {/* City and Zip */}
+        <div className="grid grid-cols-2 gap-2">
+          <Label htmlFor="city" className="text-sm font-semibold text-black/50">
+            City
+          </Label>
+          <Label htmlFor="zip-code" className="text-sm font-semibold text-black/50">
+            Zip Code
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="city"
+            name="city"
+            onChange={event => setInfo({ city: event.target.value })}
+            placeholder="City *"
+            required={!isAnonymous}
+            value={info.city}
+          />
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            disabled={isAnonymous}
+            id="zip-code"
+            name="zip-code"
+            onChange={event => setInfo({ zip: event.target.value })}
+            placeholder="Zip code *"
+            required={!isAnonymous}
+            value={info.zip}
+          />
+        </div>
+
+        {/* Email */}
+        <div className="space-y-2">
+          <Label htmlFor="email" className="text-sm font-semibold text-black/50">
+            Email Address
+          </Label>
+          <Input
+            className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            id="email"
+            name="email"
+            onChange={event => setInfo({ email: event.target.value })}
+            placeholder={`Email address${isAnonymous ? '' : ' *'}`}
+            required={!isAnonymous}
+            type="email"
+            value={info.email}
+          />
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="tax-invoice"
+              checked={info.has_tax_invoice}
+              disabled={isAnonymous}
+              onCheckedChange={(checked) => setInfo({ has_tax_invoice: checked as boolean })}
+            />
+            <Label htmlFor="tax-invoice" className="text-sm font-medium text-black/50">
+              Send me the tax invoice
+            </Label>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="note" className="text-sm font-semibold text-black/50">
+            Leave a note
+          </Label>
+          <Textarea
+            className="h-30 border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+            id="note"
+            name="note"
+            onChange={event => setInfo({ note: event.target.value })}
+            placeholder="Note"
+            value={info.note}
+            rows={5}
+          />
+        </div>
 
         {/* Navigation Buttons */}
         <CtaFooter
@@ -349,10 +353,15 @@ export default function DonationStep2({
           disabled={info.same_as_contact}
           id="shipping-name"
           name="shipping-name"
-          onChange={event => setInfo({ shipping_name: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              name: event.target.value
+            } as ShipInfo
+          })}
           placeholder="Your name *"
           required={!info.same_as_contact}
-          value={info.shipping_name || ''}
+          value={info.ship_info?.name || ''}
         />
       </div>
 
@@ -366,19 +375,29 @@ export default function DonationStep2({
           disabled={info.same_as_contact}
           id="shipping-address1"
           name="shipping-address1"
-          onChange={event => setInfo({ shipping_address1: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              address1: event.target.value
+            } as ShipInfo
+          })}
           placeholder="Line 1*"
           required={!info.same_as_contact}
-          value={info.shipping_address1 || ''}
+          value={info.ship_info?.address1 || ''}
         />
         <Input
           className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
           disabled={info.same_as_contact}
           id="shipping-address2"
           name="shipping-address2"
-          onChange={event => setInfo({ shipping_address2: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              address2: event.target.value
+            } as ShipInfo
+          })}
           placeholder="Line 2"
-          value={info.shipping_address2 || ''}
+          value={info.ship_info?.address2 || ''}
         />
       </div>
 
@@ -395,20 +414,30 @@ export default function DonationStep2({
           disabled={info.same_as_contact}
           id="shipping-country"
           name="shipping-country"
-          onChange={event => setInfo({ shipping_country: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              country: event.target.value
+            } as ShipInfo
+          })}
           placeholder="Country *"
           required={!info.same_as_contact}
-          value={info.shipping_country || ''}
+          value={info.ship_info?.country || ''}
         />
         <Input
           className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
           disabled={info.same_as_contact}
           id="shipping-state"
           name="shipping-state"
-          onChange={event => setInfo({ shipping_state: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              state: event.target.value
+            } as ShipInfo
+          })}
           placeholder="State *"
           required={!info.same_as_contact}
-          value={info.shipping_state || ''}
+          value={info.ship_info?.state || ''}
         />
       </div>
 
@@ -425,20 +454,30 @@ export default function DonationStep2({
           disabled={info.same_as_contact}
           id="shipping-city"
           name="shipping-city"
-          onChange={event => setInfo({ shipping_city: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              city: event.target.value
+            } as ShipInfo
+          })}
           placeholder="City *"
           required={!info.same_as_contact}
-          value={info.shipping_city || ''}
+          value={info.ship_info?.city || ''}
         />
         <Input
           className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
           disabled={info.same_as_contact}
           id="shipping-zip"
           name="shipping-zip"
-          onChange={event => setInfo({ shipping_zip: event.target.value })}
+          onChange={event => setInfo({
+            ship_info: {
+              ...info.ship_info,
+              zip: event.target.value
+            } as ShipInfo
+          })}
           placeholder="Zip code *"
           required={!info.same_as_contact}
-          value={info.shipping_zip || ''}
+          value={info.ship_info?.zip || ''}
         />
       </div>
 
@@ -451,11 +490,18 @@ export default function DonationStep2({
           className="border placeholder:text-sm placeholder:font-semibold"
           id="contact-email"
           name="contact-email"
-          onChange={event => setInfo({ contact_email: event.target.value })}
+          onChange={event => {
+            setInfo({
+              ship_info: {
+                ...info.ship_info,
+                email: event.target.value
+              } as ShipInfo
+            });
+          }}
           placeholder="Email address *"
           required
           type="email"
-          value={info.contact_email || ''}
+          value={info?.ship_info?.email ?? ''}
         />
       </div>
 
@@ -468,11 +514,18 @@ export default function DonationStep2({
           className="border placeholder:text-sm placeholder:font-semibold"
           id="contact-phone"
           name="contact-phone"
-          onChange={event => setInfo({ contact_phone: event.target.value })}
+          onChange={event => {
+            setInfo({
+              ship_info: {
+                ...info.ship_info,
+                phone: event.target.value
+              } as ShipInfo
+            });
+          }}
           placeholder="Phone Number *"
           required
           type="tel"
-          value={info.contact_phone || ''}
+          value={info?.ship_info?.phone ?? ''}
         />
       </div>
 

--- a/app/_components/crowdfunding/step2.tsx
+++ b/app/_components/crowdfunding/step2.tsx
@@ -25,12 +25,52 @@ export default function DonationStep2({
   const [isCompany, setIsCompany] = useState<boolean>(false);
   const [isSubmittable, setIsSubmittable] = useState<boolean>(false);
 
+  // 内部子步骤管理
+  type SubStep = 'contact-info' | 'shipping-address';
+  const [currentSubStep, setCurrentSubStep] = useState<SubStep>('contact-info');
+
+  // 处理前进到下一个子步骤
+  const handleContactNext = () => {
+    setCurrentSubStep('shipping-address');
+  };
+
+  // 处理返回到上一个子步骤
+  const handleGoBackToContact = () => {
+    setCurrentSubStep('contact-info');
+  };
+
+  // 处理"Same as contact address"功能
+  const handleSameAsContact = (checked: boolean) => {
+    setInfo({ same_as_contact: checked });
+    
+    if (checked) {
+      // 复制联系信息到收货地址
+      const shippingName = isCompany ? info.company_name : `${info.first_name || ''} ${info.last_name || ''}`.trim();
+      
+      setInfo({
+        shipping_name: shippingName,
+        shipping_address1: info.address1,
+        shipping_address2: info.address2,
+        shipping_country: info.country,
+        shipping_state: info.state,
+        shipping_city: info.city,
+        shipping_zip: info.zip,
+        contact_email: info.email,
+        contact_phone: info.contact_phone || '',
+      });
+    }
+  };
+
   function doSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const target = event.target as HTMLFormElement;
     if (target.matches(':invalid')) return;
 
-    goToNextStep();
+    if (currentSubStep === 'contact-info') {
+      handleContactNext();
+    } else {
+      goToNextStep();
+    }
   }
   function onChange() {
     if (form.current) {
@@ -42,22 +82,25 @@ export default function DonationStep2({
     onChange();
   }, []);
 
-  return (
-    <form
-      className="space-y-6 pt-8"
-      onChange={onChange}
-      onSubmit={doSubmit}
-      ref={form}
-    >
-      <div className="flex items-center justify-center relative">
-        <button
-          onClick={goToPreviousStep}
-          className="absolute left-0 hidden sm:block"
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <h1 className="text-xl font-semibold text-center text-gray-900">Leave your contract information</h1>
-      </div>
+  // 联系方式界面
+  if (currentSubStep === 'contact-info') {
+    return (
+      <form
+        className="space-y-6 pt-8"
+        onChange={onChange}
+        onSubmit={doSubmit}
+        ref={form}
+      >
+        <div className="flex items-center justify-center relative">
+          <button
+            type="button"
+            onClick={goToPreviousStep}
+            className="absolute left-0 hidden sm:block"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <h1 className="text-xl font-semibold text-center text-gray-900">Leave your contact information</h1>
+        </div>
 
       {/* Company/Institution Checkbox */}
       <div className="flex items-center space-x-3">
@@ -244,23 +287,201 @@ export default function DonationStep2({
         />
       </div>
 
+        {/* Navigation Buttons */}
+        <CtaFooter
+          buttonLabel="Next"
+          buttonType="submit"
+          isSubmittable={isSubmittable}
+        >
+          <div className="col-span-2 flex items-center justify-center space-x-2 relative z-[1] mb-3">
+            <Checkbox
+              id="anonymous"
+              checked={isAnonymous}
+              onCheckedChange={(checked) => setIsAnonymous(checked as boolean)}
+            />
+            <Label htmlFor="anonymous" className="text-sm font-medium">
+              Make my pledge anonymous
+            </Label>
+          </div>
+        </CtaFooter>
+      </form>
+    );
+  }
+
+  // 收货地址界面
+  return (
+    <form
+      className="space-y-6 pt-8"
+      onChange={onChange}
+      onSubmit={doSubmit}
+      ref={form}
+    >
+      <div className="flex items-center justify-center relative">
+        <button
+          type="button"
+          onClick={handleGoBackToContact}
+          className="absolute left-0 hidden sm:block"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <h1 className="text-xl font-semibold text-center text-gray-900">Your shipping address</h1>
+      </div>
+
+      {/* Same as contact address checkbox */}
+      <div className="flex items-center space-x-3">
+        <Checkbox
+          id="same-address"
+          checked={info.same_as_contact}
+          onCheckedChange={handleSameAsContact}
+        />
+        <Label htmlFor="same-address" className="text-sm font-semibold">
+          Same as the contact address
+        </Label>
+      </div>
+
+      {/* Shipping Name */}
+      <div className="space-y-2">
+        <Label htmlFor="shipping-name" className="text-sm font-semibold text-black/50">
+          Name
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-name"
+          name="shipping-name"
+          onChange={event => setInfo({ shipping_name: event.target.value })}
+          placeholder="Your name *"
+          required={!info.same_as_contact}
+          value={info.shipping_name || ''}
+        />
+      </div>
+
+      {/* Shipping Address Fields */}
+      <div className="space-y-2">
+        <Label htmlFor="shipping-address1" className="text-sm font-semibold text-black/50">
+          Address
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-address1"
+          name="shipping-address1"
+          onChange={event => setInfo({ shipping_address1: event.target.value })}
+          placeholder="Line 1*"
+          required={!info.same_as_contact}
+          value={info.shipping_address1 || ''}
+        />
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-address2"
+          name="shipping-address2"
+          onChange={event => setInfo({ shipping_address2: event.target.value })}
+          placeholder="Line 2"
+          value={info.shipping_address2 || ''}
+        />
+      </div>
+
+      {/* Shipping Country and State */}
+      <div className="grid grid-cols-2 gap-2">
+        <Label htmlFor="shipping-country" className="text-sm font-semibold text-black/50">
+          Country
+        </Label>
+        <Label htmlFor="shipping-state" className="text-sm font-semibold text-black/50">
+          State
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-country"
+          name="shipping-country"
+          onChange={event => setInfo({ shipping_country: event.target.value })}
+          placeholder="Country *"
+          required={!info.same_as_contact}
+          value={info.shipping_country || ''}
+        />
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-state"
+          name="shipping-state"
+          onChange={event => setInfo({ shipping_state: event.target.value })}
+          placeholder="State *"
+          required={!info.same_as_contact}
+          value={info.shipping_state || ''}
+        />
+      </div>
+
+      {/* Shipping City and Zip */}
+      <div className="grid grid-cols-2 gap-2">
+        <Label htmlFor="shipping-city" className="text-sm font-semibold text-black/50">
+          City
+        </Label>
+        <Label htmlFor="shipping-zip" className="text-sm font-semibold text-black/50">
+          Zip Code
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-city"
+          name="shipping-city"
+          onChange={event => setInfo({ shipping_city: event.target.value })}
+          placeholder="City *"
+          required={!info.same_as_contact}
+          value={info.shipping_city || ''}
+        />
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold disabled:border-black/20"
+          disabled={info.same_as_contact}
+          id="shipping-zip"
+          name="shipping-zip"
+          onChange={event => setInfo({ shipping_zip: event.target.value })}
+          placeholder="Zip code *"
+          required={!info.same_as_contact}
+          value={info.shipping_zip || ''}
+        />
+      </div>
+
+      {/* Contact Email Address */}
+      <div className="space-y-2">
+        <Label htmlFor="contact-email" className="text-sm font-semibold text-black/50">
+          Contact Email Address
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold"
+          id="contact-email"
+          name="contact-email"
+          onChange={event => setInfo({ contact_email: event.target.value })}
+          placeholder="Email address *"
+          required
+          type="email"
+          value={info.contact_email || ''}
+        />
+      </div>
+
+      {/* Contact Phone Number */}
+      <div className="space-y-2">
+        <Label htmlFor="contact-phone" className="text-sm font-semibold text-black/50">
+          Contact Phone Number
+        </Label>
+        <Input
+          className="border placeholder:text-sm placeholder:font-semibold"
+          id="contact-phone"
+          name="contact-phone"
+          onChange={event => setInfo({ contact_phone: event.target.value })}
+          placeholder="Phone Number *"
+          required
+          type="tel"
+          value={info.contact_phone || ''}
+        />
+      </div>
+
       {/* Navigation Buttons */}
       <CtaFooter
         buttonType="submit"
-        goToPreviousStep={goToPreviousStep}
+        goToPreviousStep={handleGoBackToContact}
         isSubmittable={isSubmittable}
-      >
-        <div className="col-span-2 flex items-center justify-center space-x-2 relative z-[1] mb-3">
-          <Checkbox
-            id="anonymous"
-            checked={isAnonymous}
-            onCheckedChange={(checked) => setIsAnonymous(checked as boolean)}
-          />
-          <Label htmlFor="anonymous" className="text-sm font-medium">
-            Make my pledge anonymous
-          </Label>
-        </div>
-      </CtaFooter>
+      />
     </form>
   )
 }

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -228,7 +228,7 @@ export default function DonationStep4({
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({ message: response.statusText }));
-        const errorMessage = (errorData as any).message || response.statusText;
+        const errorMessage = (errorData as Error).message || response.statusText;
 
         // 检查是否是交易验证错误
         if (errorMessage.includes('Transaction validation failed')) {

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -209,7 +209,8 @@ export default function DonationStep4({
           'content-type': 'application/json',
         },
         body: JSON.stringify({
-          ...omit(info, ['id', 'amount', 'created_at', 'updated_at', 'selected_reward', 'has_selected_reward', 'pledge_without_reward']),
+          ...omit(info, ['id', 'amount', 'email', 'created_at', 'updated_at', 'selected_reward', 'has_selected_reward', 'pledge_without_reward']),
+          email: info.email ? info.email : (info.contact_email || ''),
           amount: convertAmountBasedOnCurrency(info.amount as number, info.currency),
           has_tax_invoice: Number(info.has_tax_invoice),
           is_anonymous: Number(info.is_anonymous),
@@ -362,7 +363,7 @@ export default function DonationStep4({
       <div className="mb-12 text-center">
         <p className="text-sm text-gray-900 leading-5">
           Your payment method will be charged immediately if the project hits its goal and you'll receive a confirmation email at{' '}
-          <span className="font-semibold">{info.email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
+          <span className="font-semibold">{info.email || info.contact_email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
         </p>
         <p className="text-sm text-gray-900 leading-5 mt-4">
           Any shipping costs and applicable taxes will be charged separately, when the creator is ready to begin fulfillment.

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -47,8 +47,8 @@ export default function DonationStep4({
   const [isSolanaTransaction, setIsSolanaTransaction] = useState<boolean>(false);
   const [riskAcknowledged, setRiskAcknowledged] = useState<boolean>(false);
   // 动态获取配置
-  const networkConfig = BLOCKCHAIN_CONFIG.networks[info.network as keyof typeof BLOCKCHAIN_CONFIG.networks];
-  const currencyConfig = BLOCKCHAIN_CONFIG.currencies[info.currency as keyof typeof BLOCKCHAIN_CONFIG.currencies];
+  const networkConfig = BLOCKCHAIN_CONFIG.networks[ info.network as keyof typeof BLOCKCHAIN_CONFIG.networks ];
+  const currencyConfig = BLOCKCHAIN_CONFIG.currencies[ info.currency as keyof typeof BLOCKCHAIN_CONFIG.currencies ];
   const currencyNetworkConfig = getCurrencyNetworkConfig(info.currency, info.network);
   const recipientAddress = getProjectWalletAddress(project, info.network); // 读出众筹合约地址
 

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, TerminalIcon } from 'lucide-react';
+import { ArrowLeftIcon, TerminalIcon } from '@phosphor-icons/react';
 import { APIResponse, DonationInfo } from '@/types';
 import { useState, useEffect } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -358,7 +358,7 @@ export default function DonationStep4({
           title="Go back to previous step"
           aria-label="Go back to previous step"
         >
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeftIcon className="h-5 w-5" />
         </button>
         <h1 className="text-xl font-semibold text-center text-gray-900">Finish your pledge</h1>
       </div>
@@ -367,7 +367,7 @@ export default function DonationStep4({
       <div className="mb-12 text-center">
         <p className="text-sm text-gray-900 leading-5">
           Your payment method will be charged immediately if the project hits its goal and you'll receive a confirmation email at{' '}
-          <span className="font-semibold">{info.email || info?.ship_info.email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
+          <span className="font-semibold">{info.email || info?.ship_info?.email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
         </p>
         <p className="text-sm text-gray-900 leading-5 mt-4">
           Any shipping costs and applicable taxes will be charged separately, when the creator is ready to begin fulfillment.

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -47,8 +47,8 @@ export default function DonationStep4({
   const [isSolanaTransaction, setIsSolanaTransaction] = useState<boolean>(false);
   const [riskAcknowledged, setRiskAcknowledged] = useState<boolean>(false);
   // 动态获取配置
-  const networkConfig = BLOCKCHAIN_CONFIG.networks[ info.network as keyof typeof BLOCKCHAIN_CONFIG.networks ];
-  const currencyConfig = BLOCKCHAIN_CONFIG.currencies[ info.currency as keyof typeof BLOCKCHAIN_CONFIG.currencies ];
+  const networkConfig = BLOCKCHAIN_CONFIG.networks[info.network as keyof typeof BLOCKCHAIN_CONFIG.networks];
+  const currencyConfig = BLOCKCHAIN_CONFIG.currencies[info.currency as keyof typeof BLOCKCHAIN_CONFIG.currencies];
   const currencyNetworkConfig = getCurrencyNetworkConfig(info.currency, info.network);
   const recipientAddress = getProjectWalletAddress(project, info.network); // 读出众筹合约地址
 
@@ -209,8 +209,8 @@ export default function DonationStep4({
           'content-type': 'application/json',
         },
         body: JSON.stringify({
-          ...omit(info, ['id', 'amount', 'email', 'created_at', 'updated_at', 'selected_reward', 'has_selected_reward', 'pledge_without_reward']),
-          email: info.email ? info.email : (info.contact_email || ''),
+          ...omit(info, ['id', 'amount', 'email', 'created_at', 'updated_at', 'selected_reward', 'has_selected_reward', 'pledge_without_reward', 'same_as_contact']),
+          email: info.email ? info.email : (info.ship_info?.email || ''),
           amount: convertAmountBasedOnCurrency(info.amount as number, info.currency),
           has_tax_invoice: Number(info.has_tax_invoice),
           is_anonymous: Number(info.is_anonymous),
@@ -221,12 +221,14 @@ export default function DonationStep4({
           wallet_address: walletAddress || address || '',
           project_slug: project.project_slug,
           reward_id: info.selected_reward?.id || null,
+          // 将 ship_info 对象转换为 JSON 字符串
+          ship_info: info.ship_info ? JSON.stringify(info.ship_info) : null,
         }),
       });
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({ message: response.statusText }));
-        const errorMessage = errorData.message || response.statusText;
+        const errorMessage = (errorData as any).message || response.statusText;
 
         // 检查是否是交易验证错误
         if (errorMessage.includes('Transaction validation failed')) {
@@ -238,7 +240,8 @@ export default function DonationStep4({
         return;
       }
 
-      const { data, validation } = (await response.json()) as APIResponse<number> & {
+      const { data, tx_id, validation } = (await response.json()) as APIResponse<number> & {
+        tx_id: number,
         validation?: { verified: boolean }
       };
 
@@ -247,15 +250,16 @@ export default function DonationStep4({
         console.log('Transaction verified successfully:');
       }
 
-      info.id = data;
-      
+      info.id = tx_id;
+      info.index = data;
+
       // Set transaction info for step 5
       onTransactionInfo?.({
         hash: transactionHash,
         walletAddress: walletAddress || address || '',
         recipientAddress: recipientAddress || '',
       });
-      
+
       setIsSubmitting(false);
       goToNextStep();
     } catch (e) {
@@ -363,7 +367,7 @@ export default function DonationStep4({
       <div className="mb-12 text-center">
         <p className="text-sm text-gray-900 leading-5">
           Your payment method will be charged immediately if the project hits its goal and you'll receive a confirmation email at{' '}
-          <span className="font-semibold">{info.email || info.contact_email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
+          <span className="font-semibold">{info.email || info?.ship_info.email || 'your registered email'}</span>. Your pledge cannot be canceled or modified.
         </p>
         <p className="text-sm text-gray-900 leading-5 mt-4">
           Any shipping costs and applicable taxes will be charged separately, when the creator is ready to begin fulfillment.

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -266,7 +266,7 @@ export default function DonationStep4({
   async function doSubmit() {
     // Check donation amount validity
     if (!info.amount || info.amount <= 0) {
-      setMessage('Invalid donation amount');
+      setMessage('Invalid amount');
       return;
     }
 

--- a/app/_components/crowdfunding/step4.tsx
+++ b/app/_components/crowdfunding/step4.tsx
@@ -484,14 +484,14 @@ export default function DonationStep4({
         <p className="text-xs font-normal text-black/80 leading-4">
           By submitting your pledge, you agree to Intuipay's{' '}
           <a
-            href="#"
+            href="/terms-of-use"
             className="underline hover:no-underline"
           >
             Terms of Use
           </a>
           {', and '}
           <a
-            href="#"
+            href="/privacy-policy"
             className="underline hover:no-underline"
           >
             Privacy Policy

--- a/app/_components/crowdfunding/step5.tsx
+++ b/app/_components/crowdfunding/step5.tsx
@@ -52,7 +52,7 @@ export default function DonationStep5({
         <h1 className="text-xl font-semibold text-black">
           Thank you for your support! You are the {info.index || 1} backer now.
         </h1>
-        <p className="text-sm text-black font-medium">{project.thanks_note || `You are the ${index} backer now.`} We apperiate your support, stay tuned for our future progress.</p>
+        <p className="text-sm text-black font-medium">{project.thanks_note || `You are the ${index} backer now.`} We appreciate your support, stay tuned for our future progress.</p>
       </div>
 
       <div className="w-full px-6 py-4 bg-neutral-100 rounded-lg border border-black/10 space-y-4">

--- a/app/_components/crowdfunding/step5.tsx
+++ b/app/_components/crowdfunding/step5.tsx
@@ -50,7 +50,7 @@ export default function DonationStep5({
     <div className="space-y-6 flex flex-col items-center">
       <div className="text-center space-y-2">
         <h1 className="text-xl font-semibold text-black">
-          Thank you for your support!
+          Thank you for your support! You are the {info.index || 1} backer now.
         </h1>
         <p className="text-sm text-black font-medium">{project.thanks_note || `You are the ${index} backer now.`} We apperiate your support, stay tuned for our future progress.</p>
       </div>
@@ -78,11 +78,6 @@ export default function DonationStep5({
         
         <div className="flex justify-between items-center">
           <span className="text-black/60 text-xs">Pledge Amount</span>
-          <span className="text-black text-xs">{(info.dollar ?? 0).toLocaleString()} USD</span>
-        </div>
-        
-        <div className="flex justify-between items-center">
-          <span className="text-black/60 text-xs">Currency</span>
           <span className="text-black text-xs">{info.amount} {info.currency}</span>
         </div>
         

--- a/app/_components/profile/about-tab.tsx
+++ b/app/_components/profile/about-tab.tsx
@@ -43,7 +43,7 @@ export default function AboutTab({ profile }: AboutTabProps) {
             </div>
             <div className="box-border flex gap-3 items-center justify-start p-0 relative shrink-0">
               <div className="font-semibold relative shrink-0 text-black text-[14px]">
-                <p className="block leading-5">{profile.privacy_level ? "Only show my name and avatar" : "Show all my profile info"}</p>
+                <p className="block leading-5">{profile.privacy_level ? 'Only show my name and avatar' : 'Show all my profile info'}</p>
               </div>
             </div>
           </div>
@@ -75,8 +75,8 @@ export default function AboutTab({ profile }: AboutTabProps) {
                   .sort((a, b) => {
                     const keyA = a.label.toLowerCase()
                     const keyB = b.label.toLowerCase()
-                    const urlA = socialLinks[keyA]
-                    const urlB = socialLinks[keyB]
+                    const urlA = socialLinks[ keyA ]
+                    const urlB = socialLinks[ keyB ]
 
                     // 有链接的排在前面，没有链接的排在后面
                     if (urlA && !urlB) return -1
@@ -85,7 +85,7 @@ export default function AboutTab({ profile }: AboutTabProps) {
                   })
                   .map(sm => {
                     const key = sm.label.toLowerCase()
-                    const url = socialLinks[key]
+                    const url = socialLinks[ key ]
                     const Icon = sm.icon as any
 
                     if (url) {

--- a/app/_components/profile/about-tab.tsx
+++ b/app/_components/profile/about-tab.tsx
@@ -1,6 +1,4 @@
 import { Profile } from '@/types'
-import { Card, CardTitle, CardContent } from '@/components/ui/card'
-import { Form, FormField, FormItem, FormLabel, FormControl } from '@/components/ui/form'
 import { SocialMedias } from '@/data/social-medias'
 
 interface AboutTabProps {
@@ -16,70 +14,110 @@ export default function AboutTab({ profile }: AboutTabProps) {
   // 提供一个伪表单上下文（只读展示，用于复用 Form 生态样式，未真正提交）
   return (
     <div className="space-y-6">
-      <Card className="p-6">
-        <CardTitle className="mb-6 text-lg sm:text-xl font-semibold">Basic info</CardTitle>
-        <CardContent className="p-0">
-          <div className="grid gap-6">
-            <div>
-              <p className="text-xs sm:text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Location</p>
-              <p className="text-sm sm:text-base font-semibold text-gray-900">{profile.location || 'Not specified'}</p>
+      <div className="bg-white box-border flex flex-col gap-8 items-start justify-start p-6 relative rounded-lg border border-black/10">
+        <div className="box-border flex items-center justify-start p-0 relative shrink-0 w-full">
+          <div className="font-semibold relative shrink-0 text-black text-[20px] leading-6">
+            Basic info
+          </div>
+        </div>
+        <div className="box-border flex flex-col gap-6 items-start justify-start p-0 relative shrink-0 w-full">
+          <div className="box-border flex flex-col font-semibold gap-2 items-start justify-start p-0 relative shrink-0 text-[14px] w-full">
+            <div className="relative shrink-0 text-black/50 w-full">
+              <p className="block leading-5">Location</p>
             </div>
-            <div>
-              <p className="text-xs sm:text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Time Zone</p>
-              <p className="text-sm sm:text-base font-semibold text-gray-900">{profile.timezone || 'Not specified'}</p>
-            </div>
-            <div>
-              <p className="text-xs sm:text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Privacy</p>
-              <p className="text-sm sm:text-base font-semibold text-gray-900">Only show my name and avatar</p>
+            <div className="relative shrink-0 text-black w-full">
+              <p className="block leading-5">{profile.location || 'Shanghai, China'}</p>
             </div>
           </div>
-        </CardContent>
-      </Card>
+          <div className="box-border flex flex-col font-semibold gap-2 items-start justify-start p-0 relative shrink-0 text-[14px] w-full">
+            <div className="relative shrink-0 text-black/50 w-full">
+              <p className="block leading-5">Time Zone</p>
+            </div>
+            <div className="relative shrink-0 text-black w-full">
+              <p className="block leading-5">{profile.timezone || '(GMT-10:00) Hawaii'}</p>
+            </div>
+          </div>
+          <div className="box-border flex flex-col gap-2 items-start justify-start p-0 relative shrink-0 w-full">
+            <div className="font-semibold relative shrink-0 text-[14px] text-black/50">
+              <p className="block leading-5">Privacy</p>
+            </div>
+            <div className="box-border flex gap-3 items-center justify-start p-0 relative shrink-0">
+              <div className="font-semibold relative shrink-0 text-black text-[14px]">
+                <p className="block leading-5">{profile.privacy_level ? "Only show my name and avatar" : "Show all my profile info"}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-      <Card className="p-6">
-        <CardTitle className="mb-6 text-lg sm:text-xl font-semibold">Detailed info</CardTitle>
-        <CardContent className="p-0 space-y-6">
-          <div>
-            <p className="text-xs sm:text-sm font-semibold text-gray-500 uppercase tracking-wide mb-2">Bio</p>
-            <p className="text-sm sm:text-base text-gray-900 leading-relaxed whitespace-pre-line">{profile.bio || 'No bio available'}</p>
+      <div className="bg-white box-border flex flex-col gap-8 items-start justify-start p-6 relative rounded-lg border border-black/10">
+        <div className="box-border flex items-center justify-start p-0 relative shrink-0 w-full">
+          <div className="font-semibold relative shrink-0 text-black text-[20px] leading-6">
+            Detailed info
           </div>
-          <div>
-            <p className="text-xs sm:text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Social Media</p>
-            <div className="flex flex-wrap gap-3">
-              {SocialMedias.map(sm => {
-                const key = sm.label.toLowerCase()
-                const url = socialLinks[ key ]
-                const Icon = sm.icon as any
-                const common = 'p-2 transition-colors'
-                if (url) {
-                  return (
-                    <a
-                      key={sm.label}
-                      href={url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={common + ' text-gray-900 hover:text-blue-600'}
-                      title={sm.label}
-                      aria-label={`Visit ${sm.label} profile`}
-                    >
-                      <Icon size={20} />
-                    </a>
-                  )
-                }
-                return (
-                  <div
-                    key={sm.label}
-                    className={common + ' text-gray-300 cursor-not-allowed'}
-                    title={`${sm.label} not connected`}
-                  >
-                    <Icon size={20} />
-                  </div>
-                )
-              })}
+        </div>
+        <div className="box-border flex flex-col gap-6 items-start justify-start p-0 relative shrink-0 w-full">
+          <div className="box-border flex flex-col font-semibold gap-2 items-start justify-start p-0 relative shrink-0 text-[14px] w-full">
+            <div className="relative shrink-0 text-black/50 w-full">
+              <p className="block leading-5">Bio</p>
+            </div>
+            <div className="relative shrink-0 text-black w-full">
+              <p className="block leading-5">{profile.bio || 'No bio available'}</p>
             </div>
           </div>
-        </CardContent>
-      </Card>
+          <div className="box-border flex flex-col gap-2 items-start justify-start p-0 relative shrink-0 w-full">
+            <div className="font-semibold relative shrink-0 text-[14px] text-black/50">
+              <p className="block leading-5">Social Media</p>
+            </div>
+            <div className="box-border flex gap-3 items-center justify-start p-0 relative shrink-0">
+              <div className="flex items-center gap-2">
+                {SocialMedias
+                  .sort((a, b) => {
+                    const keyA = a.label.toLowerCase()
+                    const keyB = b.label.toLowerCase()
+                    const urlA = socialLinks[keyA]
+                    const urlB = socialLinks[keyB]
+
+                    // 有链接的排在前面，没有链接的排在后面
+                    if (urlA && !urlB) return -1
+                    if (!urlA && urlB) return 1
+                    return 0
+                  })
+                  .map(sm => {
+                    const key = sm.label.toLowerCase()
+                    const url = socialLinks[key]
+                    const Icon = sm.icon as any
+
+                    if (url) {
+                      return (
+                        <a
+                          key={sm.label}
+                          href={url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-black hover:text-blue-600 transition-colors"
+                          title={sm.label}
+                          aria-label={`Visit ${sm.label} profile`}
+                        >
+                          <Icon size={20} weight="fill" />
+                        </a>
+                      )
+                    }
+                    return (
+                      <div
+                        key={sm.label}
+                        className="text-black/20 cursor-not-allowed"
+                        title={`${sm.label} not connected`}
+                      >
+                        <Icon size={20} weight="regular" />
+                      </div>
+                    )
+                  })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/_components/profile/about-tab.tsx
+++ b/app/_components/profile/about-tab.tsx
@@ -26,7 +26,7 @@ export default function AboutTab({ profile }: AboutTabProps) {
               <p className="block leading-5">Location</p>
             </div>
             <div className="relative shrink-0 text-black w-full">
-              <p className="block leading-5">{profile.location || 'Shanghai, China'}</p>
+              <p className="block leading-5">{profile.location || 'Not specified'}</p>
             </div>
           </div>
           <div className="box-border flex flex-col font-semibold gap-2 items-start justify-start p-0 relative shrink-0 text-[14px] w-full">

--- a/app/_components/profile/backed-tab.tsx
+++ b/app/_components/profile/backed-tab.tsx
@@ -1,6 +1,8 @@
 import { ProjectCard } from '@/components/project-card';
 import { ProjectStatus } from '@/data/project';
 import { BackedProject } from '@/types';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 interface BackedTabProps {
   projects?: BackedProject[]; // 用户支持的项目列表，包含退款状态
@@ -12,8 +14,15 @@ export default function BackedTab({ projects }: BackedTabProps) {
 
   if (projectsToShow.length === 0) {
     return (
-      <div className="w-full text-center py-12">
-        <p className="text-black-600">You are not backing any projects.</p>
+      <div className="w-full flex flex-col items-center justify-center gap-10 py-12">
+        <p className="text-black/60 text-center text-base font-medium leading-6 max-w-[440px]">
+          You are not backing any projects.
+        </p>
+        <Link href="/projects">
+          <Button className="bg-[#2461f2] hover:bg-[#2461f2]/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+            Browse Projects
+          </Button>
+        </Link>
       </div>
     );
   }

--- a/app/_components/profile/backed-tab.tsx
+++ b/app/_components/profile/backed-tab.tsx
@@ -19,7 +19,7 @@ export default function BackedTab({ projects }: BackedTabProps) {
           You are not backing any projects.
         </p>
         <Link href="/projects">
-          <Button className="bg-[#2461f2] hover:bg-[#2461f2]/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+          <Button className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
             Browse Projects
           </Button>
         </Link>

--- a/app/_components/profile/backed-tab.tsx
+++ b/app/_components/profile/backed-tab.tsx
@@ -18,11 +18,11 @@ export default function BackedTab({ projects }: BackedTabProps) {
         <p className="text-black/60 text-center text-base font-medium leading-6 max-w-[440px]">
           You are not backing any projects.
         </p>
-        <Link href="/projects">
-          <Button className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+        <Button asChild type="button" className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+          <Link href="/projects">
             Browse Projects
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </div>
     );
   }

--- a/app/_components/profile/edit-profile-dialog.tsx
+++ b/app/_components/profile/edit-profile-dialog.tsx
@@ -337,9 +337,10 @@ export function EditProfileDialog({ open, onOpenChange, profile, onProfileUpdate
                   control={form.control}
                   name={`socialLinks.${key}`}
                   render={({ field }) => (
-                    <FormItem className="flex items-center justify-between gap-4">
-                      <FormLabel className="flex items-center gap-2 min-w-28 text-sm font-medium text-gray-900">
-                        <sm.icon className="w-5 h-5 text-gray-600" />{sm.label}
+                    <FormItem className="flex items-center justify-between">
+                      <FormLabel className="flex items-center gap-2 min-w-fit text-sm font-medium text-gray-900">
+                        <sm.icon weight="fill" className="w-5 h-5 text-gray-900" />
+                        {sm.label}
                       </FormLabel>
                       <FormControl>
                         <Input
@@ -347,7 +348,7 @@ export function EditProfileDialog({ open, onOpenChange, profile, onProfileUpdate
                           {...field}
                           hasRing
                           placeholder={key === 'website' ? 'https://' : `https://${key}.com/username`}
-                          className="w-[420px] text-sm"
+                          className="w-96 text-sm"
                         />
                       </FormControl>
                       <FormMessage />

--- a/app/_components/profile/edit-profile-dialog.tsx
+++ b/app/_components/profile/edit-profile-dialog.tsx
@@ -70,7 +70,7 @@ export function EditProfileDialog({ open, onOpenChange, profile, onProfileUpdate
     bio: profile.bio || '',
     number: profile.number || '',
     displayImage: profile.display_image || '',
-    privacyOnly: false,
+    privacyOnly: profile.privacy_level === 1,
     socialLinks: {
       website: parsedLinks.website || '',
       facebook: parsedLinks.facebook || '',
@@ -110,6 +110,7 @@ export function EditProfileDialog({ open, onOpenChange, profile, onProfileUpdate
             number: values.number,
             display_image: values.displayImage,
             social_links: JSON.stringify(values.socialLinks),
+            privacy_level: values.privacyOnly ? 1 : 0,
         }),
       })
       const result = await response.json() as { code: number; message?: string; data?: any }

--- a/app/_components/profile/profile-tabs.tsx
+++ b/app/_components/profile/profile-tabs.tsx
@@ -23,19 +23,19 @@ export default function ProfileTabs({ profile, myBacked, myProjects }: ProfileTa
           <TabsList className="bg-transparent p-0 h-auto gap-5">
             <TabsTrigger
               value="about"
-              className="px-6 py-3 font-semibold text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-[#2461f2] data-[state=active]:border-[#2461f2] data-[state=active]:shadow-none hover:text-[#2461f2] rounded-none"
+              className="px-6 py-3 font-semibold text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:shadow-none hover:text-blue-600 rounded-none"
             >
               About
             </TabsTrigger>
             <TabsTrigger
               value="backed"
-              className="px-6 py-3 font-medium text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-[#2461f2] data-[state=active]:border-[#2461f2] data-[state=active]:shadow-none hover:text-[#2461f2] rounded-none"
+              className="px-6 py-3 font-medium text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:shadow-none hover:text-blue-600 rounded-none"
             >
               Backed
             </TabsTrigger>
             <TabsTrigger
               value="raised"
-              className="px-6 py-3 font-medium text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-[#2461f2] data-[state=active]:border-[#2461f2] data-[state=active]:shadow-none hover:text-[#2461f2] rounded-none"
+              className="px-6 py-3 font-medium text-sm leading-5 border-b-2 border-transparent data-[state=active]:bg-transparent data-[state=active]:text-blue-600 data-[state=active]:border-blue-600 data-[state=active]:shadow-none hover:text-blue-600 rounded-none"
             >
               Raised
             </TabsTrigger>

--- a/app/_components/profile/profile-tabs.tsx
+++ b/app/_components/profile/profile-tabs.tsx
@@ -6,6 +6,7 @@ import BackedTab from './backed-tab';
 import RaisedTab from './raised-tab';
 import { CoinVerticalIcon, ArrowUpRightIcon } from '@phosphor-icons/react/ssr';
 import { Profile, ProjectInfo, BackedProject } from '@/types';
+import Link from 'next/link';
 
 interface ProfileTabsProps {
   profile: Profile;
@@ -41,15 +42,20 @@ export default function ProfileTabs({ profile, myBacked, myProjects }: ProfileTa
           </TabsList>
 
           {/* Creator Dashboard Link */}
-          <div className="flex items-center gap-4 px-3 py-2">
+          <Link 
+            href={process.env.NEXT_PUBLIC_DASHBOARD_URL || '#'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-4 px-3 py-2 hover:bg-blue-50 rounded-lg transition-colors group"
+          >
             <div className="flex items-center gap-2">
-              <CoinVerticalIcon size={20} className="text-blue-600" />
-              <span className="font-medium text-sm leading-5 text-blue-600">
+              <CoinVerticalIcon size={20} className="text-blue-600 group-hover:text-blue-700" />
+              <span className="font-medium text-sm leading-5 text-blue-600 group-hover:text-blue-700">
                 Creator Dashboard
               </span>
             </div>
-            <ArrowUpRightIcon size={20} className="text-blue-600" />
-          </div>
+            <ArrowUpRightIcon size={20} className="text-blue-600 group-hover:text-blue-700" />
+          </Link>
         </div>
 
         {/* Tab Content */}

--- a/app/_components/profile/raised-tab.tsx
+++ b/app/_components/profile/raised-tab.tsx
@@ -17,11 +17,11 @@ export default function RaisedTab({ projects }: RaisedTabProps) {
         <p className="text-black/60 text-center text-base font-medium leading-6 max-w-[440px]">
           You are not raising any projects.
         </p>
-        <Link href={`${process.env.NEXT_PUBLIC_DASHBOARD_URL}/project/new`} target="_blank" rel="noopener noreferrer">
-          <Button className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+        <Button asChild type="button" className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+          <Link href={`${process.env.NEXT_PUBLIC_DASHBOARD_URL}/project/new`} target="_blank" rel="noopener noreferrer">
             Raise Now
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </div>
     );
   }

--- a/app/_components/profile/raised-tab.tsx
+++ b/app/_components/profile/raised-tab.tsx
@@ -18,7 +18,7 @@ export default function RaisedTab({ projects }: RaisedTabProps) {
           You are not raising any projects.
         </p>
         <Link href={`${process.env.NEXT_PUBLIC_DASHBOARD_URL}/project/new`} target="_blank" rel="noopener noreferrer">
-          <Button className="bg-[#2461f2] hover:bg-[#2461f2]/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+          <Button className="bg-blue-600 hover:bg-blue-600/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
             Raise Now
           </Button>
         </Link>

--- a/app/_components/profile/raised-tab.tsx
+++ b/app/_components/profile/raised-tab.tsx
@@ -1,5 +1,7 @@
 import { ProjectCard } from '@/components/project-card';
 import { ProjectInfo } from '@/types';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 interface RaisedTabProps {
   projects?: ProjectInfo[];
@@ -11,9 +13,15 @@ export default function RaisedTab({ projects }: RaisedTabProps) {
 
   if (projectsToShow.length === 0) {
     return (
-      <div className="w-full text-center py-12">
-        <p className="text-gray-500 text-lg">No projects created yet</p>
-        <p className="text-gray-400 text-sm mt-2">Projects you create will appear here</p>
+      <div className="w-full flex flex-col items-center justify-center gap-10 py-12">
+        <p className="text-black/60 text-center text-base font-medium leading-6 max-w-[440px]">
+          You are not raising any projects.
+        </p>
+        <Link href={`${process.env.NEXT_PUBLIC_DASHBOARD_URL}/project/new`} target="_blank" rel="noopener noreferrer">
+          <Button className="bg-[#2461f2] hover:bg-[#2461f2]/90 text-white px-4 py-2 rounded-[40px] text-sm font-medium leading-5">
+            Raise Now
+          </Button>
+        </Link>
       </div>
     );
   }

--- a/app/api/donation/route.ts
+++ b/app/api/donation/route.ts
@@ -129,7 +129,7 @@ export async function POST(req: Request) {
     return new Response(
       JSON.stringify({
         code: 0,
-        data: data[ 0 ].last_insert_id,
+        data: data[ 0 ].index,
         validation: {
           verified: true,
         },

--- a/app/api/donation/route.ts
+++ b/app/api/donation/route.ts
@@ -130,6 +130,7 @@ export async function POST(req: Request) {
       JSON.stringify({
         code: 0,
         data: data[ 0 ].index,
+        tx_id: data[ 0 ].last_insert_id,
         validation: {
           verified: true,
         },

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
   const userId = headersList.get('x-user-id') ?? '';
 
   const params = await req.json() as Record<string, any>;
-  const { location, timezone, bio, social_links, number, first_name, last_name, display_image } = params;
+  const { location, timezone, bio, social_links, number, first_name, last_name, display_image, privacy_level } = params;
 
   console.log('Updating profile for user:', userId, location, timezone, bio, social_links, number, first_name, last_name, display_image);
   try {
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
       first_name,
       last_name,
       display_image,
+      privacy_level,
     });
     return NextResponse.json({ code: 0, data: res });
   } catch (e) {

--- a/app/donate/support/page.tsx
+++ b/app/donate/support/page.tsx
@@ -50,10 +50,10 @@ export default function SupportPage() {
                 <p>
                   <a
                     className="hover:text-blue-600"
-                    href="mailto:help@intuipay.com"
+                    href="mailto:support@intuipay.xyz"
                     target="_blank"
                   >
-                    help@intuipay.com
+                    support@intuipay.xyz
                   </a>
                 </p>
               </div>
@@ -78,7 +78,7 @@ export default function SupportPage() {
             />
           </Link>
           <Link
-            href="/donate/tos"
+            href="/terms-of-use"
             className="hover:text-blue-600 transition-colors flex items-center gap-2"
           >
             Terms & Conditions

--- a/components/refund-dialog.tsx
+++ b/components/refund-dialog.tsx
@@ -408,7 +408,7 @@ export function RefundDialog({ open, onOpenChange, projectId, campaignId, contra
               <Button
                 onClick={handleRefundRequest}
                 disabled={isProcessingRefund || isContractPending || isConfirming}
-                className="flex-1 bg-[#2461f2] hover:bg-[#1a4cc7] disabled:opacity-50"
+                className="flex-1 bg-blue-600 hover:bg-[#1a4cc7] disabled:opacity-50"
               >
                 {isProcessingRefund || isContractPending ? (
                   <div className="flex items-center gap-2">

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -178,7 +178,7 @@ export function SiteHeader({ user }: SiteHeaderProps) {
                   href={link.href}
                   className={`text-base font-medium py-2 transition-colors ${
                     link.label === 'Donate' 
-                      ? 'text-[#2461F2]' 
+                      ? 'text-blue-600' 
                       : 'text-black hover:text-gray-600'
                   }`}
                   onClick={() => setMobileMenuOpen(false)}

--- a/lib/appkit.ts
+++ b/lib/appkit.ts
@@ -77,9 +77,9 @@ export const config = createConfig({
     }),
   ] : [],
   transports: {
-    [mainnet.id]: http(),
-    [sepolia.id]: http(),
-    [pharosTestnet.id]: http(),
-    [eduTestnet.id]: http(),
+    [ mainnet.id ]: http(),
+    [ sepolia.id ]: http(),
+    [ pharosTestnet.id ]: http(),
+    [ eduTestnet.id ]: http(),
   },
 })

--- a/lib/send-email.ts
+++ b/lib/send-email.ts
@@ -62,7 +62,7 @@ export function getDonationProps(project: ProjectInfo, donation: DonationInfo): 
     endAt: project.end_at,
     from: project.org_name,
     id: donation.id,
-    index: donation.id,
+    index: donation.index || 1,
     projectName: project.project_name,
     status: 'successful',
     txHash: donation.tx_hash || '',

--- a/types/index.ts
+++ b/types/index.ts
@@ -92,6 +92,18 @@ export type DonationInfo = {
   pledge_without_reward?: boolean;
   reward_id?: number;
 
+  // 收货地址相关字段
+  same_as_contact?: boolean;
+  shipping_name?: string;
+  shipping_address1?: string;
+  shipping_address2?: string;
+  shipping_country?: string;
+  shipping_state?: string;
+  shipping_city?: string;
+  shipping_zip?: string;
+  contact_email?: string;
+  contact_phone?: string;
+
   created_at?: string;
   updated_at?: string;
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -237,6 +237,7 @@ export interface Profile {
   first_name: string;
   last_name: string;
   display_image: string;
+  privacy_level?: number; // 0: 未选择隐私条件, 1: 选中了隐私条件
 }
 
 // 用户支持的项目类型，包含项目信息和用户的退款状态

--- a/types/index.ts
+++ b/types/index.ts
@@ -13,6 +13,18 @@ export type Currency = DropdownItemProps & {
   anotherSymbol: string;
 }
 
+export type ShipInfo = {
+  name: string;
+  address1: string;
+  address2?: string;
+  country: string;
+  state: string;
+  city: string;
+  zip: string;
+  email: string;
+  phone: string;
+}
+
 export type University = DropdownItemProps & {
   country?: string;
   countryIcon: string;
@@ -94,15 +106,8 @@ export type DonationInfo = {
 
   // 收货地址相关字段
   same_as_contact?: boolean;
-  shipping_name?: string;
-  shipping_address1?: string;
-  shipping_address2?: string;
-  shipping_country?: string;
-  shipping_state?: string;
-  shipping_city?: string;
-  shipping_zip?: string;
-  contact_email?: string;
-  contact_phone?: string;
+  ship_info?: ShipInfo; // 收货地址信息对象
+  index?: number;
 
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
一些UI问题的修复

- [x] 将 step1 拆分为2个子步骤填奖励和钱包信息
- [x] 将 step2 拆分为2个子步骤，填联系方式和收货地址
- [x] 项目 banner 图片平铺
- [x] profile 页加上到 dashboard 的链接
- [x] profile 页编辑资料时传 privacy_level
- [x] 修改 profile about-tab，对照设计稿优化icon，优化UI
- [x] profile backed tab，加上空界面的 浏览项目按钮
- [x] profile raised tab，加上空界面的创建项目按钮
- [x] step1 点击 rewards aren't guaranted 时出现文字 popover
- [x] 交易成功界面删掉 dollar 字段，只保留 crypto currency 字段，优化一些文案
- [x] support 界面更新 email地址，更新 terms of use 链接
- [x] 众筹项目用到的图标使用 @phosphor-icons/react 库
- [x] 编辑profile的对话框，社交媒体的icon使用 filled 的版本