### PR TITLE
uploaded s3 filename should keep ext

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { toS3ImageName } from "@/lib/utils";
+
+describe('Test Utils', () => {
+  describe('toS3ImageName', () => {
+    it('should convert image name to S3 format', () => {
+      expect(toS3ImageName('My Image.png')).toBe('my-image.png');
+      expect(toS3ImageName('Another Image.JPG')).toBe('another-image.JPG');
+      expect(toS3ImageName('wuyanzu-1.webp')).toBe('wuyanzu-1.webp');
+      // slugify 没法处理locale，所以会trim文件名，但是影响应该不大
+      expect(toS3ImageName('我的头像.jpg')).toBe('.jpg');
+
+      expect(toS3ImageName('avatar (1).png')).toBe('avatar-1.png');
+      expect(toS3ImageName('avatar （21）.png')).toBe('avatar-21.png');
+    });
+  });
+});

--- a/components/ui/avatar-upload.tsx
+++ b/components/ui/avatar-upload.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
-import slugify from 'slugify';
+import { toS3ImageName } from '@/lib/utils';
 import { APIResponse } from '@/types';
 
 interface AvatarUploadProps {
@@ -146,11 +146,7 @@ export function AvatarUpload({
   const uploadImage = async (file: File) => {
     try {
       const { type, name } = file;
-      const slugifiedName = slugify(name, {
-        lower: true,
-        strict: true,
-        trim: true,
-      });
+      const slugifiedName = toS3ImageName(name);
 
       // Step 1: Get presigned URL
       const presignResponse = await fetch(`${process.env.NEXT_PUBLIC_DASHBOARD_URL}/api/upload`, {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,10 +1,11 @@
-import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 import { RewardShipMethod } from '@intuipay/shared/constants';
 import { REWARD_SHIP_METHOD_LABELS } from '@/data';
+import slugify from 'slugify';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 export function enumToKeyLabel(enumValue: Record<string, string | number>): Record<string, string> {
@@ -15,10 +16,10 @@ export function enumToKeyLabel(enumValue: Record<string, string | number>): Reco
 }
 
 export const getEnumKey = <T extends Record<string, string | number>>(
-  enumValue: T, 
+  enumValue: T,
   value: string | number
 ): keyof T | string => {
-  const entry = Object.entries(enumValue).find(([key, val]) => 
+  const entry = Object.entries(enumValue).find(([key, val]) =>
     (val as number | string).toString() === value.toString() && isNaN(Number(key))
   );
   return entry ? entry[ 0 ] : value.toString();
@@ -36,12 +37,28 @@ function findEnumEntryByValue<T extends Record<string, string | number>>(
 
 export const getRewardShipMethodLabel = (value: string): string => {
   const entry = findEnumEntryByValue(RewardShipMethod, value);
-  
+
   if (entry) {
     const key = entry[ 0 ] as keyof typeof RewardShipMethod;
     return REWARD_SHIP_METHOD_LABELS[ key ] || key;
   }
-  
+
   return value;
 };
 
+export const toS3ImageName = (name: string): string => {
+  // 分离文件名和扩展名
+  const lastDotIndex = name.lastIndexOf('.');
+  const fileName = lastDotIndex > 0 ? name.substring(0, lastDotIndex) : name;
+  const fileExtension = lastDotIndex > 0 ? name.substring(lastDotIndex) : '';
+
+  // 只对文件名部分进行 slugify 处理，保留原始扩展名
+  const slugifiedFileName = slugify(fileName, {
+    lower: true,
+    strict: true,
+    trim: true,
+  });
+
+  const slugifiedName = slugifiedFileName + fileExtension;
+  return slugifiedName;
+};

--- a/package.json
+++ b/package.json
@@ -107,6 +107,5 @@
     "wagmi": "^2.15.6",
     "wrangler": "^4.30.0"
   },
-  "packageManager": "pnpm@10.14.0",
-  "type": "module"
+  "packageManager": "pnpm@10.14.0"
 }


### PR DESCRIPTION
之前简单用 slugify 处理上传的文件名，会导致 .jpg 的这个点丢失，导致未来从 s3 下载文件会打不开

现在这个PR做了一些保护，分开处理文件名跟后缀

<img width="1463" height="610" alt="image" src="https://github.com/user-attachments/assets/a9e11001-0bf2-4bb0-85ba-9a659d670e19" />

如果这个修改可以，还要同步到 dashboard，因为也是一样的问题