### PR TITLE
project detail and project list tab use crypto unit not dollar

### DIFF
--- a/app/_components/projects/project-detail.tsx
+++ b/app/_components/projects/project-detail.tsx
@@ -21,6 +21,8 @@ import { useMemo, useState } from 'react';
 import { enumToKeyLabel } from '@/lib/utils';
 import { ProjectCategories, ProjectTypes } from '@/data';
 import { ProjectDonationMethods } from '@/data';
+import { BLOCKCHAIN_CONFIG } from "@/config/blockchain";
+import { formatUnits } from 'viem';
 
 
 type ProjectDetailClientLayoutProps = {
@@ -102,6 +104,22 @@ export default function ProjectDetailClientLayout({
     return project.rewards ? JSON.parse(project.rewards) : [];
   }, [project]);
 
+  const parseTokenId = () => {
+      const tokenId = project.tokens[project.networks[0]] ?? 'usdc';
+      return tokenId;
+    }
+    const projectTokenId = parseTokenId();
+    const selectedCurrency = projectTokenId
+      ? BLOCKCHAIN_CONFIG.currencies[
+      projectTokenId as keyof typeof BLOCKCHAIN_CONFIG.currencies
+      ]
+      : undefined;
+  
+    // 货币符号
+    const currencySymbol = selectedCurrency?.symbol ?? "USDC";
+    const projectAmountInCrypto = formatUnits(BigInt(project.amount), selectedCurrency?.decimals ?? 6);
+    const projectGoalAmountInCrypto = formatUnits(BigInt(project.goal_amount), selectedCurrency?.decimals ?? 6);
+
   return (
     <div className="container">
       <div className="text-center mb-10">
@@ -159,9 +177,9 @@ export default function ProjectDetailClientLayout({
               <span className="font-semibold text-lg truncate">{project.org_name}</span>
             </div>
             <div>
-              <p className="text-2xl sm:text-3xl font-bold mb-2">${project.amount.toLocaleString() || 0}</p>
+              <p className="text-2xl sm:text-3xl font-bold mb-2">{projectAmountInCrypto} {currencySymbol}</p>
               <p className="text-sm text-neutral-darkgray mb-2">
-                pledged of ${(project.goal_amount / 100).toLocaleString()}
+                pledged of {projectGoalAmountInCrypto} {currencySymbol} goal
               </p>
               <Progress
                 value={project.amount}

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -34,6 +34,13 @@ export function ProjectCard({ project, isRefunded }: ProjectCardProps) {
     const tokenId = tokens[networks[0]] ?? 'usdc';
     return tokenId;
   }
+
+  const parseContractAddress = () => {
+    const wallets = project.wallets ? JSON.parse(project.wallets) : {};
+    const networks = project.networks ? JSON.parse(project.networks) : [];
+    const contractAddress = wallets[networks[0]] ?? '';
+    return contractAddress;
+  }
   const projectTokenId = parseTokenId();
   const selectedCurrency = projectTokenId
     ? BLOCKCHAIN_CONFIG.currencies[
@@ -44,6 +51,7 @@ export function ProjectCard({ project, isRefunded }: ProjectCardProps) {
   // 货币符号
   const currencySymbol = selectedCurrency?.symbol ?? "USDC";
   const projectAmountInCrypto = formatUnits(BigInt(project.amount), selectedCurrency?.decimals ?? 6);
+  const currentContractAddress = parseContractAddress();
 
   // 判断是否为backed状态（传入了isRefunded参数）
   const isBackedView = isRefunded !== undefined;
@@ -111,7 +119,7 @@ export function ProjectCard({ project, isRefunded }: ProjectCardProps) {
                         onOpenChange={setIsWalletDialogOpen}
                         projectId={project.id}
                         campaignId={project.campaign_id}
-                        contractAddress={'0xce714E8190a22E1475aaF01D904eb34502FC3904'}
+                        contractAddress={currentContractAddress}
                       />
                     </>
                   )


### PR DESCRIPTION
项目列表页，项目详情页，用到 amount, goal_amount 的地方，都从数据库返回的很多0的大整数，转为对应货币的小数，如 goal_amount 为 1000000000000000000，那么在前端展示就是 1 ETH

列表卡片：
<img width="1149" height="623" alt="image" src="https://github.com/user-attachments/assets/f07046a4-ed7d-4f92-8f68-832e7a4c30be" />

详情页：
<img width="1295" height="800" alt="image" src="https://github.com/user-attachments/assets/6091b995-d759-40d1-ada8-d72caddce9d1" />

